### PR TITLE
feat(web): add OpenAI-to-Codex usage workflow guides

### DIFF
--- a/apps/web/app/guides/page.tsx
+++ b/apps/web/app/guides/page.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, BookOpenText, MagnifyingGlass } from "@phosphor-icons/react
 import { GuideCard } from "@/components/guides/guide-card";
 import { GuideIndex } from "@/components/guides/guide-index";
 import { GuideJsonLd } from "@/components/guides/guide-json-ld";
-import { brandGuides, deliveryGuides, generalGuides, productGuides } from "@/lib/guides/registry";
+import { brandGuides, deliveryGuides, generalGuides, productGuides, workflowGuides } from "@/lib/guides/registry";
 import { BRAND_NAMES, breadcrumbJsonLd } from "./_shared";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
@@ -53,7 +53,26 @@ export default async function GuidesPage({ searchParams }: { searchParams: Searc
     (!delivery || guide.deliveryType === delivery) && includesQuery([guide.title, guide.summary, guide.shortLabel], query),
   );
   const general = Object.values(generalGuides).filter((guide) => includesQuery([guide.title, guide.description], query));
+  const workflows = Object.values(workflowGuides).filter((guide) =>
+    includesQuery(
+      [
+        guide.title,
+        guide.description,
+        ...guide.flow,
+        "Cockpit",
+        "Sub2API",
+        "CC Switch",
+        "Codex++",
+      ],
+      query,
+    ),
+  );
   const hasFilters = Boolean(query || brand || product || delivery);
+  const guideCount = Object.keys(brandGuides).length
+    + Object.keys(productGuides).length
+    + Object.keys(deliveryGuides).length
+    + Object.keys(generalGuides).length
+    + Object.keys(workflowGuides).length;
 
   return (
     <main id="main-content">
@@ -70,8 +89,8 @@ export default async function GuidesPage({ searchParams }: { searchParams: Searc
           <aside className="rounded-[14px] border border-black bg-[color:var(--panel)] p-6">
             <BookOpenText size={27} aria-hidden="true" />
             <p className="mt-5 text-sm font-semibold">当前教程目录</p>
-            <p className="mt-2 text-4xl font-semibold tracking-[-.055em]">{1 + Object.keys(brandGuides).length + Object.keys(productGuides).length + Object.keys(deliveryGuides).length + Object.keys(generalGuides).length}</p>
-            <p className="mt-2 text-sm leading-6 text-black/55">覆盖 5 个品牌、22 个产品、10 种交付方式和 6 篇通用指南。</p>
+            <p className="mt-2 text-4xl font-semibold tracking-[-.055em]">{1 + guideCount}</p>
+            <p className="mt-2 text-sm leading-6 text-black/55">覆盖 {Object.keys(brandGuides).length} 个品牌、{Object.keys(productGuides).length} 个产品、{Object.keys(deliveryGuides).length} 种交付方式、{Object.keys(generalGuides).length} 篇通用指南和 {Object.keys(workflowGuides).length} 个工作流。</p>
           </aside>
         </div>
       </header>
@@ -112,7 +131,7 @@ export default async function GuidesPage({ searchParams }: { searchParams: Searc
           </form>
           {hasFilters ? (
             <div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-black/55">
-              <span>找到 {brands.length + products.length + deliveries.length + general.length} 篇相关教程</span>
+              <span>找到 {brands.length + products.length + deliveries.length + general.length + workflows.length} 篇相关教程</span>
               <Link href="/guides" className="flex min-h-11 items-center font-medium text-black hover:underline">清空筛选</Link>
             </div>
           ) : null}
@@ -126,6 +145,12 @@ export default async function GuidesPage({ searchParams }: { searchParams: Searc
 
         <GuideIndex id="brands" title="全部品牌" description="查看品牌产品范围、套餐选择、常见交付和官方帮助入口。" empty={brands.length === 0}>
           {brands.map((guide) => <GuideCard key={guide.brand} href={`/guides/brands/${guide.brand}`} title={guide.title} description={guide.description} meta={BRAND_NAMES[guide.brand]} />)}
+        </GuideIndex>
+
+        <GuideIndex id="workflows" title="OpenAI 与 Codex 使用工作流" description="从账号或 API 交付开始，选择 Cockpit、Sub2API、CC Switch 或 Codex++ 完成实际接入。" empty={workflows.length === 0}>
+          {workflows.map((guide) => (
+            <GuideCard key={guide.slug} href={`/guides/workflows/${guide.slug}`} title={guide.title} description={guide.description} meta="OpenAI / Codex 工作流" />
+          ))}
         </GuideIndex>
 
         <GuideIndex id="products" title="全部产品教程" description="按稳定产品分类查看购买前确认、交付方式和使用步骤。" empty={products.length === 0}>

--- a/apps/web/app/guides/page.tsx
+++ b/apps/web/app/guides/page.tsx
@@ -5,6 +5,7 @@ import { GuideCard } from "@/components/guides/guide-card";
 import { GuideIndex } from "@/components/guides/guide-index";
 import { GuideJsonLd } from "@/components/guides/guide-json-ld";
 import { brandGuides, deliveryGuides, generalGuides, productGuides, workflowGuides } from "@/lib/guides/registry";
+import type { ProductSlug } from "@/lib/guides/types";
 import { BRAND_NAMES, breadcrumbJsonLd } from "./_shared";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
@@ -53,8 +54,27 @@ export default async function GuidesPage({ searchParams }: { searchParams: Searc
     (!delivery || guide.deliveryType === delivery) && includesQuery([guide.title, guide.summary, guide.shortLabel], query),
   );
   const general = Object.values(generalGuides).filter((guide) => includesQuery([guide.title, guide.description], query));
-  const workflows = Object.values(workflowGuides).filter((guide) =>
-    includesQuery(
+  const workflows = Object.values(workflowGuides).filter((guide) => {
+    if (brand && brand !== "openai") return false;
+    if (product) {
+      const productGuide = productGuides[product as ProductSlug];
+      const referenced = productGuide?.workflowReferences?.some(
+        (reference) => reference.workflowSlug === guide.slug,
+      ) ?? false;
+      if (!referenced) return false;
+    }
+    if (delivery) {
+      const referencedByDelivery = Object.values(productGuides).some(
+        (productGuide) =>
+          productGuide.brand === "openai" &&
+          (productGuide.supportedDeliveryTypes as readonly string[]).includes(delivery) &&
+          (productGuide.workflowReferences ?? []).some(
+            (reference) => reference.workflowSlug === guide.slug,
+          ),
+      );
+      if (!referencedByDelivery) return false;
+    }
+    return includesQuery(
       [
         guide.title,
         guide.description,
@@ -65,8 +85,8 @@ export default async function GuidesPage({ searchParams }: { searchParams: Searc
         "Codex++",
       ],
       query,
-    ),
-  );
+    );
+  });
   const hasFilters = Boolean(query || brand || product || delivery);
   const guideCount = Object.keys(brandGuides).length
     + Object.keys(productGuides).length

--- a/apps/web/app/guides/products/[productSlug]/page.tsx
+++ b/apps/web/app/guides/products/[productSlug]/page.tsx
@@ -13,7 +13,9 @@ import { GuideSection } from "@/components/guides/guide-section";
 import { GuideSources } from "@/components/guides/guide-sources";
 import { GuideSteps } from "@/components/guides/guide-steps";
 import { GuideWalkthrough } from "@/components/guides/guide-walkthrough";
-import { getDeliveryGuide, getProductGuide, productGuides } from "@/lib/guides/registry";
+import { GuideWorkflowCards } from "@/components/guides/guide-workflow-cards";
+import { getDeliveryGuide, getProductGuide, getWorkflowGuide, productGuides } from "@/lib/guides/registry";
+import type { ProductWorkflowReference, WorkflowGuide } from "@/lib/guides/types";
 import { articleJsonLd, BRAND_NAMES, breadcrumbJsonLd, faqJsonLd, guideMetadata, howToJsonLd } from "../../_shared";
 
 type PageProps = { params: Promise<{ productSlug: string }> };
@@ -45,6 +47,17 @@ export default async function ProductGuidePage({ params }: PageProps) {
   const deliveryEntries = guide.supportedDeliveryTypes.map((type) => getDeliveryGuide(type)).filter((item) => item !== undefined);
   const comparisonBlocks = guide.overview.filter((block) => block.type === "comparison");
   const overviewBlocks = guide.overview.filter((block) => block.type === "paragraph");
+  const workflowEntries = (guide.workflowReferences ?? [])
+    .map((reference) => ({
+      reference,
+      guide: getWorkflowGuide(reference.workflowSlug),
+    }))
+    .filter(
+      (entry): entry is {
+        reference: ProductWorkflowReference;
+        guide: WorkflowGuide;
+      } => Boolean(entry.guide),
+    );
   const problemRows = deliveryEntries.flatMap((delivery) =>
     delivery.commonProblems.map((item) => [delivery.shortLabel, item.problem, item.action]),
   );
@@ -58,6 +71,9 @@ export default async function ProductGuidePage({ params }: PageProps) {
     { id: "buying-checklist", label: "购买前确认" },
     { id: "delivery-guides", label: "购买后使用" },
     { id: "verification", label: "确认服务生效" },
+    ...(workflowEntries.length
+      ? [{ id: "usage-workflows", label: "用于 Codex" }]
+      : []),
     { id: "problems", label: "常见错误" },
     { id: "security", label: "安全和隐私" },
     { id: "after-sales", label: "售后证据" },
@@ -156,6 +172,16 @@ export default async function ProductGuidePage({ params }: PageProps) {
         </GuideSection>
 
         <GuideSection id="verification" title="如何确认服务已经生效"><GuideChecklist items={guide.verificationChecklist} /></GuideSection>
+
+        {workflowEntries.length ? (
+          <GuideSection
+            id="usage-workflows"
+            title="购买后如何用于 Codex"
+            intro="先确认账号、套餐或席位已经生效，再选择本地账号池、服务器账号池，或直接 API 路线。Cockpit/Sub2API 负责上游账号与 API，CC Switch/Codex++ 负责把接口配置给 Codex。"
+          >
+            <GuideWorkflowCards entries={workflowEntries} />
+          </GuideSection>
+        ) : null}
 
         <GuideSection id="problems" title="常见错误与处理">
           <GuideComparison columns={["交付方式", "问题", "安全处理"]} rows={problemRows} />

--- a/apps/web/app/guides/workflows/[workflowSlug]/page.tsx
+++ b/apps/web/app/guides/workflows/[workflowSlug]/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "@phosphor-icons/react/ssr";
+import { notFound } from "next/navigation";
+import { GuideBlocks } from "@/components/guides/guide-blocks";
+import { GuideCallout } from "@/components/guides/guide-callout";
+import { GuideChecklist } from "@/components/guides/guide-checklist";
+import { GuideComparison } from "@/components/guides/guide-comparison";
+import { GuideFaq } from "@/components/guides/guide-faq";
+import { GuideJsonLd } from "@/components/guides/guide-json-ld";
+import { GuideLayout } from "@/components/guides/guide-layout";
+import { GuideSection } from "@/components/guides/guide-section";
+import { GuideSources } from "@/components/guides/guide-sources";
+import { GuideWalkthrough } from "@/components/guides/guide-walkthrough";
+import { getWorkflowGuide, workflowGuides } from "@/lib/guides/registry";
+import { articleJsonLd, breadcrumbJsonLd, faqJsonLd, guideMetadata, howToJsonLd } from "../../_shared";
+
+type PageProps = { params: Promise<{ workflowSlug: string }> };
+
+export function generateStaticParams() {
+  return Object.values(workflowGuides).map((guide) => ({ workflowSlug: guide.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { workflowSlug } = await params;
+  const guide = getWorkflowGuide(workflowSlug);
+  if (!guide) return { title: "工作流教程不存在", robots: { index: false, follow: true } };
+  return guideMetadata(guide.title, guide.description, `/guides/workflows/${guide.slug}`);
+}
+
+export default async function WorkflowGuidePage({ params }: PageProps) {
+  const { workflowSlug } = await params;
+  const guide = getWorkflowGuide(workflowSlug);
+  if (!guide) notFound();
+
+  const path = `/guides/workflows/${guide.slug}`;
+  const toc = [
+    { id: "what-is", label: "这条路线解决什么" },
+    { id: "flow", label: "完整链路" },
+    { id: "audience", label: "适合哪些用户" },
+    { id: "prerequisites", label: "开始前准备" },
+    ...guide.variants.map((item) => ({
+      id: `variant-${item.id}`,
+      label: item.id === "cc-switch" ? "方案 A：CC Switch" : "方案 B：Codex++",
+    })),
+    { id: "verification", label: "如何确认成功" },
+    { id: "problems", label: "常见错误" },
+    { id: "security", label: "安全与隐私" },
+    { id: "faq", label: "常见问题" },
+    { id: "sources", label: "资料来源" },
+  ];
+
+  return (
+    <>
+      <GuideJsonLd
+        data={[
+          breadcrumbJsonLd([
+            { name: "首页", path: "/" },
+            { name: "教程中心", path: "/guides" },
+            { name: guide.title, path },
+          ]),
+          articleJsonLd({ title: guide.title, description: guide.description, path, dateModified: guide.lastReviewedAt }),
+          ...guide.variants.map((item) =>
+            howToJsonLd({
+              title: item.title,
+              description: item.description,
+              steps: item.walkthrough.steps.map((step) => step.action),
+            }),
+          ),
+          faqJsonLd(guide.faq),
+        ]}
+      />
+      <GuideLayout
+        breadcrumbs={[
+          { href: "/", label: "首页" },
+          { href: "/guides", label: "教程中心" },
+          { label: guide.title },
+        ]}
+        title={guide.title}
+        description={guide.description}
+        lastReviewedAt={guide.lastReviewedAt}
+        toc={toc}
+        footer={
+          <div className="space-y-6">
+            <GuideCallout tone="warning" title="第三方与凭证风险">
+              Cockpit Tools、Sub2API、CC Switch 和 Codex++ 均为第三方项目，与 OpenAI 和 AI Price Radar 没有隶属关系。不要把完整 Cookie、Access Token、Refresh Token、API Key、恢复码或 auth.json 上传到本站、聊天机器人或公开仓库。
+            </GuideCallout>
+            <Link href="/guides" className="tactile flex min-h-12 items-center justify-between text-sm font-semibold">
+              返回教程中心
+              <ArrowRight size={18} aria-hidden="true" />
+            </Link>
+          </div>
+        }
+      >
+        <GuideSection id="what-is" title="这条路线解决什么">
+          <GuideBlocks blocks={guide.overview} />
+        </GuideSection>
+
+        <GuideSection id="flow" title="完整链路" intro="上游负责账号与 API，下游客户端负责把接口配置给 Codex。">
+          <ol aria-label="工作流步骤" className="grid gap-3">
+            {guide.flow.map((node, index) => (
+              <li key={node} className="flex flex-wrap items-center gap-3 rounded-[12px] border hairline bg-[color:var(--panel)] px-4 py-3 text-sm font-semibold">
+                <span>{node}</span>
+                {index < guide.flow.length - 1 ? (
+                  <ArrowRight size={18} className="text-black/40" aria-hidden="true" />
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        </GuideSection>
+
+        <GuideSection id="audience" title="适合哪些用户">
+          <GuideChecklist items={guide.audience} />
+        </GuideSection>
+
+        <GuideSection id="prerequisites" title="开始前准备">
+          <GuideChecklist items={guide.prerequisites} />
+        </GuideSection>
+
+        {guide.variants.map((item) => (
+          <GuideSection
+            key={item.id}
+            id={`variant-${item.id}`}
+            title={item.title}
+            intro={item.description}
+          >
+            <GuideWalkthrough walkthrough={item.walkthrough} />
+          </GuideSection>
+        ))}
+
+        <GuideSection id="verification" title="如何确认成功">
+          <GuideChecklist items={guide.verificationChecklist} />
+        </GuideSection>
+
+        <GuideSection id="problems" title="常见错误">
+          <GuideComparison
+            columns={["问题", "可能原因", "处理动作"]}
+            rows={guide.commonProblems.map((item) => [item.problem, item.likelyCause, item.action])}
+          />
+        </GuideSection>
+
+        <GuideSection id="security" title="安全与隐私">
+          <GuideCallout tone="danger" title="重要风险不会折叠">
+            <ul className="list-disc space-y-2 pl-5">
+              {guide.riskNotes.map((note) => <li key={note}>{note}</li>)}
+            </ul>
+          </GuideCallout>
+        </GuideSection>
+
+        <GuideSection id="faq" title="常见问题">
+          <GuideFaq items={guide.faq} />
+        </GuideSection>
+
+        <GuideSection id="sources" title="资料来源">
+          <GuideSources sources={guide.sources} />
+        </GuideSection>
+      </GuideLayout>
+    </>
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 import { getProducts } from "@/lib/api";
-import { brandGuides, deliveryGuides, generalGuides, productGuides } from "@/lib/guides/registry";
+import { brandGuides, deliveryGuides, generalGuides, productGuides, workflowGuides } from "@/lib/guides/registry";
 
 export const dynamic = "force-dynamic";
 
@@ -34,6 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...Object.keys(productGuides).map((productSlug) => ({ url: `${SITE_URL}/guides/products/${encodeURIComponent(productSlug)}`, lastModified: GUIDE_LAST_MODIFIED })),
     ...Object.keys(deliveryGuides).map((deliveryType) => ({ url: `${SITE_URL}/guides/delivery/${encodeURIComponent(deliveryType)}`, lastModified: GUIDE_LAST_MODIFIED })),
     ...Object.keys(generalGuides).map((slug) => ({ url: `${SITE_URL}/guides/${encodeURIComponent(slug)}`, lastModified: GUIDE_LAST_MODIFIED })),
+    ...Object.keys(workflowGuides).map((slug) => ({ url: `${SITE_URL}/guides/workflows/${encodeURIComponent(slug)}`, lastModified: GUIDE_LAST_MODIFIED })),
   ];
   try {
     const catalog = await getProducts("sort=quality");

--- a/apps/web/components/guides/guide-sources.tsx
+++ b/apps/web/components/guides/guide-sources.tsx
@@ -9,7 +9,9 @@ export function GuideSources({ sources }: { sources: readonly OfficialSource[] }
           <a href={source.url} target="_blank" rel="noreferrer" className="group grid min-h-14 gap-1 rounded-[12px] border hairline bg-[color:var(--panel)] p-4 hover:border-black sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
             <span>
               <span className="font-semibold group-hover:underline">{source.title}</span>
-              <span className="mt-1 block text-xs text-[color:var(--muted)]">{source.publisher}，核验于 {source.lastCheckedAt}</span>
+              <span className="mt-1 block text-xs text-[color:var(--muted)]">
+                {source.kind === "project_official" ? "项目官方" : "平台官方"} · {source.publisher}，核验于 {source.lastCheckedAt}
+              </span>
             </span>
             <ArrowSquareOut size={19} className="hidden sm:block" aria-hidden="true" />
           </a>

--- a/apps/web/components/guides/guide-workflow-cards.tsx
+++ b/apps/web/components/guides/guide-workflow-cards.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { ArrowRight } from "@phosphor-icons/react/ssr";
+import type {
+  ProductWorkflowReference,
+  WorkflowGuide,
+  WorkflowRelevance,
+} from "@/lib/guides/types";
+
+const RELEVANCE_LABELS: Record<WorkflowRelevance, string> = {
+  recommended: "推荐",
+  conditional: "条件适用",
+  advanced: "高级",
+};
+
+const RELEVANCE_STYLES: Record<WorkflowRelevance, string> = {
+  recommended: "bg-[color:var(--accent-ink)]/10 text-[color:var(--accent-ink)]",
+  conditional: "bg-black/[.06] text-black/70",
+  advanced: "bg-[#94751d]/10 text-[#7a5d16]",
+};
+
+export interface WorkflowCardEntry {
+  reference: ProductWorkflowReference;
+  guide: WorkflowGuide;
+}
+
+export function GuideWorkflowCards({ entries }: { entries: readonly WorkflowCardEntry[] }) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {entries.map(({ reference, guide }) => (
+        <Link
+          key={guide.slug}
+          href={`/guides/workflows/${guide.slug}`}
+          className="tactile group flex min-h-64 flex-col justify-between rounded-[14px] border hairline bg-[color:var(--panel)] p-5 hover:border-black focus-visible:border-black"
+        >
+          <div className="space-y-4">
+            <span className={`inline-flex min-h-7 items-center rounded-full px-3 text-xs font-semibold ${RELEVANCE_STYLES[reference.relevance]}`}>
+              {RELEVANCE_LABELS[reference.relevance]}
+            </span>
+            <h3 className="text-lg font-semibold tracking-[-.025em]">{guide.title}</h3>
+            <ol aria-label="工作流步骤" className="flex flex-wrap items-center gap-2">
+              {guide.flow.map((node, index) => (
+                <li key={node} className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                  <span className="rounded-[8px] border hairline px-2.5 py-1.5">{node}</span>
+                  {index < guide.flow.length - 1 ? (
+                    <ArrowRight size={15} className="text-black/40" aria-hidden="true" />
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+            <p className="text-sm leading-6 text-[color:var(--muted)]">适合：{reference.audience}</p>
+            <p className="text-sm leading-6 text-[color:var(--muted)]">选择条件：{reference.condition}</p>
+            {reference.note ? (
+              <p className="rounded-[10px] bg-black/[.045] p-3 text-xs leading-5 text-black/65">{reference.note}</p>
+            ) : null}
+          </div>
+          <span className="mt-5 flex min-h-11 items-center gap-2 text-sm font-medium">
+            查看完整教程
+            <ArrowRight size={17} className="transition-transform group-hover:translate-x-1" aria-hidden="true" />
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/content/guides/products.ts
+++ b/apps/web/content/guides/products.ts
@@ -5,6 +5,7 @@ import type {
   OfficialSource,
   ProductGuide,
   ProductSlug,
+  ProductWorkflowReference,
 } from "@/lib/guides/types";
 import { GUIDE_DISCLAIMER, LAST_REVIEWED_AT, OFFICIAL_SOURCES } from "./sources";
 
@@ -519,6 +520,168 @@ const apiSafetyNotes = [
   "设置用量预算和账单提醒；Key 泄露时立即撤销并轮换，同时检查异常用量。",
 ];
 
+const WORKFLOW_REFERENCE_MATRIX: Partial<Record<ProductSlug, readonly ProductWorkflowReference[]>> = {
+  "chatgpt-account": [
+    {
+      workflowSlug: "openai-codex",
+      relevance: "conditional",
+      audience: "需要确认基础账号是否包含 Codex 权限的用户",
+      condition: "账号实际拥有 Codex 权限时",
+    },
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "conditional",
+      audience: "收到可登录账号、OAuth 或可导入凭证的用户",
+      condition: "收到可登录账号、OAuth 或可导入凭证",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "需要服务器账号池的团队",
+      condition: "需要服务器账号池时",
+    },
+  ],
+  "chatgpt-plus": [
+    {
+      workflowSlug: "openai-codex",
+      relevance: "recommended",
+      audience: "先确认 Plus 和 Codex 当前可用的用户",
+      condition: "先确认 Plus 和 Codex 当前可用",
+    },
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "recommended",
+      audience: "个人电脑和多账号用户",
+      condition: "个人电脑和多账号场景",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "多设备、多用户或服务端团队",
+      condition: "多设备、多用户或服务端场景",
+    },
+  ],
+  "chatgpt-go": [
+    {
+      workflowSlug: "openai-codex",
+      relevance: "conditional",
+      audience: "需要确认 Go 是否包含 Codex 权限的用户",
+      condition: "以当前官方权限为准",
+    },
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "conditional",
+      audience: "能完成 OAuth 或凭证导入的用户",
+      condition: "能完成 OAuth 或凭证导入时",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "服务端场景的团队",
+      condition: "服务端场景",
+    },
+  ],
+  "chatgpt-k12": [
+    {
+      workflowSlug: "openai-codex",
+      relevance: "conditional",
+      audience: "工作区管理员允许的用户",
+      condition: "工作区管理员允许且席位包含相关权限",
+      note: "团队席位不等于账号所有权。管理员可能限制 Codex、查看组织策略或移除席位；不要在第三方工作区和未经授权的账号池中处理公司机密。",
+    },
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "conditional",
+      audience: "有合法登录和导入能力的工作区用户",
+      condition: "使用者有合法登录和导入能力",
+      note: "团队席位不等于账号所有权。管理员可能限制 Codex、查看组织策略或移除席位；不要在第三方工作区和未经授权的账号池中处理公司机密。",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "管理员授权的服务端团队",
+      condition: "管理员授权的服务端场景",
+      note: "团队席位不等于账号所有权。管理员可能限制 Codex、查看组织策略或移除席位；不要在第三方工作区和未经授权的账号池中处理公司机密。",
+    },
+  ],
+  "chatgpt-pro-5x": [
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "recommended",
+      audience: "个人、多账号用户",
+      condition: "个人、多账号场景",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "服务端团队",
+      condition: "服务端场景",
+    },
+  ],
+  "chatgpt-pro-20x": [
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "recommended",
+      audience: "个人、多账号用户",
+      condition: "个人、多账号场景",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "服务端团队",
+      condition: "服务端场景",
+    },
+  ],
+  "chatgpt-pro": [
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "recommended",
+      audience: "个人、多账号用户",
+      condition: "个人、多账号场景",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "服务端团队",
+      condition: "服务端场景",
+    },
+  ],
+  "openai-api-credit": [
+    {
+      workflowSlug: "api-endpoint-to-codex",
+      relevance: "recommended",
+      audience: "已有 API Key 或额度的开发者",
+      condition: "已有 API Key 或额度",
+      note: "此商品直接交付 API 使用能力，不需要先把账号导入 Cockpit。只有在你需要自行做账号池时才考虑 Sub2API。",
+    },
+  ],
+  "chatgpt-access-service": [
+    {
+      workflowSlug: "api-endpoint-to-codex",
+      relevance: "recommended",
+      audience: "已有 Base URL 和用户 Key 的用户",
+      condition: "已有 Base URL 和用户 Key",
+      note: "此商品直接交付 API 使用能力，不需要先把账号导入 Cockpit。只有在你需要自行做账号池时才考虑 Sub2API。",
+    },
+  ],
+  "codex-access": [
+    {
+      workflowSlug: "cockpit-to-codex",
+      relevance: "recommended",
+      audience: "收到 JSON、OAuth 或账号交付的用户",
+      condition: "JSON、OAuth 或账号交付",
+      note: "若交付的是团队席位，管理员可能限制或移除席位；不要把工作区凭证导入未授权账号池。",
+    },
+    {
+      workflowSlug: "sub2api-to-codex",
+      relevance: "advanced",
+      audience: "需要服务器账号池的团队",
+      condition: "服务器账号池场景",
+      note: "若交付的是团队席位，管理员可能限制或移除席位；不要把工作区凭证导入未授权账号池。",
+    },
+  ],
+};
+
 function buildProductGuide(seed: ProductSeed): ProductGuide {
   const securityNotes = seed.securityProfile === "api"
     ? apiSafetyNotes
@@ -537,6 +700,7 @@ function buildProductGuide(seed: ProductSeed): ProductGuide {
     audience: seed.audience,
     supportedDeliveryTypes: seed.supportedDeliveryTypes,
     walkthrough: seed.walkthrough,
+    workflowReferences: WORKFLOW_REFERENCE_MATRIX[seed.productSlug],
     overview: [
       { type: "paragraph", text: seed.summary },
       {

--- a/apps/web/content/guides/sources.ts
+++ b/apps/web/content/guides/sources.ts
@@ -1,12 +1,26 @@
-import type { OfficialSource } from "@/lib/guides/types";
+import type { GuideSource } from "@/lib/guides/types";
 
 export const LAST_REVIEWED_AT = "2026-08-03";
 
 export const GUIDE_DISCLAIMER =
   "AI Price Radar 只整理公开商品信息和一般使用知识，不参与交易、支付、交付或售后。第三方商品可能存在账号控制权、服务稳定性、官方条款和隐私风险。购买前请返回商品原页面确认价格、期限、交付和售后条件。";
 
-function officialSource(title: string, url: string, publisher: string): OfficialSource {
-  return { title, url, publisher, lastCheckedAt: LAST_REVIEWED_AT };
+function officialSource(title: string, url: string, publisher: string): GuideSource {
+  return { title, url, publisher, lastCheckedAt: LAST_REVIEWED_AT, kind: "platform_official" };
+}
+
+function projectSource(
+  title: string,
+  url: string,
+  publisher: string,
+): GuideSource {
+  return {
+    title,
+    url,
+    publisher,
+    lastCheckedAt: LAST_REVIEWED_AT,
+    kind: "project_official",
+  };
 }
 
 export const OFFICIAL_SOURCES = {
@@ -29,4 +43,32 @@ export const OFFICIAL_SOURCES = {
   grokApi: officialSource("xAI API Documentation", "https://docs.x.ai/", "xAI"),
   xHelp: officialSource("X Help Center", "https://help.x.com/", "X"),
   xTerms: officialSource("X Terms of Service", "https://x.com/en/tos", "X"),
+  openaiCodexConfig: officialSource(
+    "Codex configuration",
+    "https://developers.openai.com/codex/config-basic/",
+    "OpenAI",
+  ),
+} as const;
+
+export const PROJECT_SOURCES = {
+  cockpitTools: projectSource(
+    "Cockpit Tools",
+    "https://github.com/jlcodes99/cockpit-tools",
+    "jlcodes99",
+  ),
+  sub2api: projectSource(
+    "Sub2API",
+    "https://github.com/Wei-Shaw/sub2api",
+    "Wei-Shaw",
+  ),
+  ccSwitch: projectSource(
+    "CC Switch",
+    "https://github.com/farion1231/cc-switch",
+    "farion1231",
+  ),
+  codexPlusPlus: projectSource(
+    "CodexPlusPlus",
+    "https://github.com/BigPizzaV3/CodexPlusPlus",
+    "BigPizzaV3",
+  ),
 } as const;

--- a/apps/web/content/guides/workflows.ts
+++ b/apps/web/content/guides/workflows.ts
@@ -25,6 +25,9 @@ const TERMS_RISK_NOTE =
 const UI_VERSION_NOTE =
   "以你当前版本界面实际显示的 Base URL、客户端 Key、模型列表和字段名称为准，不要按本文示例端口或旧版字段硬编码。";
 
+const CODEX_PLUS_PLUS_PROTOCOL_NOTE =
+  "选择上游协议：上游原生支持 Responses API 时选择 Responses；上游只支持 Chat Completions 时选择 Chat Completions，由 Codex++ 的本地协议代理转换为 Responses。具体名称以当前 Codex++ 版本界面为准。";
+
 function step(
   title: string,
   action: string,
@@ -154,8 +157,8 @@ export const workflowGuideEntries = [
       ),
       variant(
         "codex-plusplus",
-        "服务器或中转注入路线：Sub2API 或直接 API → Codex++ → Codex Desktop",
-        "适合有服务器账号池或需要 Codex Desktop 中转注入的用户。必须通过 Codex++ 启动入口启动 Codex，注入配置才会生效。",
+        "Cockpit、Sub2API 或直接 API → Codex++ → Codex Desktop",
+        "适合个人本地账号池、服务器账号池或直接 API 用户，需要 Codex Desktop 中转注入时使用。必须通过 Codex++ 启动入口启动 Codex，注入配置才会生效。",
         {
           title: "通过 Codex++ 接入 Codex Desktop",
           intro: "Codex++ 固定指 BigPizzaV3/CodexPlusPlus。先安装官方 Codex Desktop，再安装 Codex++，最后填写中转注入。",
@@ -167,7 +170,7 @@ export const workflowGuideEntries = [
             ),
             step(
               "选择上游并取得 Base URL 与用户 Key",
-              "服务器场景使用 Sub2API 的 HTTPS Base URL 与下游用户 Key；已有直接交付的 Base URL + Key 则直接使用。",
+              "个人电脑可以使用 Cockpit 本地 API 服务，服务器场景使用 Sub2API 的 HTTPS Base URL 与下游用户 Key；已有直接交付的 Base URL + Key 则直接使用。",
               "你有一组可用的 Base URL 与 Key，且知道协议和模型名。",
             ),
             step(
@@ -177,9 +180,12 @@ export const workflowGuideEntries = [
             ),
             step(
               "打开 Codex++ Manager 配置中转注入",
-              "进入中转注入或供应商配置，填写 Base URL 与客户端 Key，选择 OpenAI-compatible / Responses 路径，然后应用配置。",
+              "进入中转注入或供应商配置，填写 Base URL 与客户端 Key，然后选择上游协议并应用配置。",
               "配置已保存，但还没有启动 Codex。",
-              { trouble: "字段名称随版本变化时，以 Codex++ Manager 当前界面为准。" },
+              {
+                items: [CODEX_PLUS_PLUS_PROTOCOL_NOTE],
+                trouble: "字段名称随版本变化时，以 Codex++ Manager 当前界面为准。",
+              },
             ),
             step(
               "退出旧 Codex 并通过 Codex++ 启动",
@@ -328,6 +334,15 @@ export const workflowGuideEntries = [
           intro: `从 Cockpit 复制 Base URL 与客户端 Key 后，再按顺序配置 CC Switch。${UI_VERSION_NOTE}`,
           steps: [
             step(
+              "先把非 Cockpit JSON 转换成 Cockpit 格式（如适用）",
+              "如果商家交付的是 CPA、Sub2 或其他非 Cockpit JSON，先在浏览器本地打开站内转换工具，下载转换后的 Cockpit JSON；没有收到 JSON 时直接跳过。",
+              "需要转换的文件已转换为 Cockpit JSON，且转换页只在本机处理文件。",
+              {
+                links: [{ label: "打开站内 JSON 转换工具", url: "/tools/json-to-cockpit" }],
+                trouble: "转换只改变文件结构，不会修复过期令牌或缺失字段；转换失败时先查看跳过原因，再联系原商家。",
+              },
+            ),
+            step(
               "从官方 Release 安装 CC Switch",
               "只从 farion1231/cc-switch 的 GitHub Releases 页面下载对应系统版本。",
               "CC Switch 安装完成。",
@@ -404,6 +419,15 @@ export const workflowGuideEntries = [
           intro: "必须从 Codex++ 启动入口启动 Codex，相关增强和中转配置才会生效。",
           steps: [
             step(
+              "先把非 Cockpit JSON 转换成 Cockpit 格式（如适用）",
+              "如果商家交付的是 CPA、Sub2 或其他非 Cockpit JSON，先在浏览器本地打开站内转换工具，下载转换后的 Cockpit JSON；没有收到 JSON 时直接跳过。",
+              "需要转换的文件已转换为 Cockpit JSON，且转换页只在本机处理文件。",
+              {
+                links: [{ label: "打开站内 JSON 转换工具", url: "/tools/json-to-cockpit" }],
+                trouble: "转换只改变文件结构，不会修复过期令牌或缺失字段；转换失败时先查看跳过原因，再联系原商家。",
+              },
+            ),
+            step(
               "确认项目来源",
               "Codex++ 固定使用 BigPizzaV3/CodexPlusPlus，从官方仓库或官方 Release 获取。",
               "你已确认使用正确的项目，而不是同名 loader 项目。",
@@ -432,9 +456,10 @@ export const workflowGuideEntries = [
               "配置已填写，没有使用固定端口或旧字段名。",
             ),
             step(
-              "选择 OpenAI-compatible / Responses 路径",
-              "按 Cockpit 当前接口选择路径，Codex 通常使用 Responses。",
-              "路径与上游接口一致。",
+              "选择上游协议",
+              "按 Cockpit 当前接口选择协议，然后应用配置。",
+              "协议与上游接口一致，具体名称以当前 Codex++ 版本界面为准。",
+              { items: [CODEX_PLUS_PLUS_PROTOCOL_NOTE] },
             ),
             step(
               "应用配置",
@@ -675,9 +700,10 @@ export const workflowGuideEntries = [
               "客户端只持有用户 Key。",
             ),
             step(
-              "选择路径并应用配置",
-              "选择 OpenAI-compatible / Responses 路径并应用配置。",
+              "选择上游协议并应用配置",
+              "按 Sub2API 当前接口选择协议并应用配置。",
               "配置已保存。",
+              { items: [CODEX_PLUS_PLUS_PROTOCOL_NOTE] },
             ),
             step(
               "退出旧 Codex 并通过 Codex++ 启动",
@@ -905,9 +931,10 @@ export const workflowGuideEntries = [
               "配置已填写。",
             ),
             step(
-              "选择路径并应用配置",
-              "选择 OpenAI-compatible / Responses 路径并应用。",
+              "选择上游协议并应用配置",
+              "按供应商支持的协议选择并应用配置。",
               "配置已保存。",
+              { items: [CODEX_PLUS_PLUS_PROTOCOL_NOTE] },
             ),
             step(
               "退出旧 Codex 并通过 Codex++ 启动",

--- a/apps/web/content/guides/workflows.ts
+++ b/apps/web/content/guides/workflows.ts
@@ -1,0 +1,991 @@
+import type {
+  GuideWalkthrough,
+  GuideWalkthroughStep,
+  WorkflowGuide,
+  WorkflowVariant,
+  WorkflowVariantId,
+} from "@/lib/guides/types";
+import { LAST_REVIEWED_AT, OFFICIAL_SOURCES, PROJECT_SOURCES } from "./sources";
+
+const THIRD_PARTY_NOTICE =
+  "Cockpit Tools、Sub2API、CC Switch 和 Codex++ 均为第三方项目，与 OpenAI 和 AI Price Radar 没有隶属关系。";
+
+const CREDENTIAL_WARNING =
+  "不要把完整 Cookie、Access Token、Refresh Token、API Key、恢复码或 auth.json 上传到 AI Price Radar、聊天机器人、公开仓库或陌生网站；不要上传或公开任何完整凭证。";
+
+const LOCAL_CONVERTER_NOTE =
+  "AI Price Radar 的 JSON 转换器只在浏览器本地处理文件；但下载并导入第三方工具后，凭证会由对应工具读取和保存。";
+
+const TEAM_SEAT_WARNING =
+  "工作区席位可被管理员限制或移除。不要在第三方管理的工作区、共享账号或未经授权的账号池中处理公司机密和个人敏感信息。";
+
+const TERMS_RISK_NOTE =
+  "账号池、共享、中转和第三方客户端可能受到平台条款、组织政策、地区、网络环境和风控限制。页面不得承诺稳定、永久或不会封号。";
+
+const UI_VERSION_NOTE =
+  "以你当前版本界面实际显示的 Base URL、客户端 Key、模型列表和字段名称为准，不要按本文示例端口或旧版字段硬编码。";
+
+function step(
+  title: string,
+  action: string,
+  result: string,
+  extra?: {
+    items?: readonly string[];
+    links?: readonly { label: string; url: string }[];
+    trouble?: string;
+  },
+): GuideWalkthroughStep {
+  return { title, action, result, ...extra };
+}
+
+function variant(
+  id: WorkflowVariantId,
+  title: string,
+  description: string,
+  walkthrough: GuideWalkthrough,
+): WorkflowVariant {
+  return { id, title, description, walkthrough };
+}
+
+export const workflowGuideEntries = [
+  {
+    slug: "openai-codex",
+    title: "OpenAI 账号购买后如何用于 Codex",
+    description:
+      "先确认账号或席位已生效，再选择本地 Cockpit、服务器 Sub2API，或直接使用已交付的 Base URL 与 API Key，最后通过 CC Switch 或 Codex++ 接入 Codex。",
+    flow: ["OpenAI 商品", "账号/API 服务层", "CC Switch 或 Codex++", "Codex"],
+    audience: [
+      "购买了 OpenAI 商品后需要真正接入 Codex 的用户",
+      "需要在本地账号池、服务器账号池和直接 API 之间选择路线的用户",
+      "需要同时理解 CC Switch 与 Codex++ 定位的用户",
+    ],
+    prerequisites: [
+      "已确认账号、套餐、席位或 API 额度已经生效。",
+      "已知道自己收到的是账号、JSON、Base URL 还是 API Key。",
+      "已阅读 OpenAI 官方 Codex 文档，并接受第三方工具的凭证与条款风险。",
+    ],
+    overview: [
+      {
+        type: "paragraph",
+        text: "Cockpit 和 Sub2API 位于上游：Cockpit 负责本地账号管理与本地 API，Sub2API 负责服务器账号池与 API 分发。CC Switch 和 Codex++ 位于用户客户端侧：CC Switch 负责供应商配置切换与本地路由，Codex++ 负责 Codex Desktop 的外部启动与中转注入。两者通常是二选一，不要求同时安装。",
+      },
+      {
+        type: "callout",
+        tone: "info",
+        title: "这不是四个平行工具",
+        text: "正确链路是：OpenAI 账号或凭证先进入 Cockpit（本地）或 Sub2API（服务器），形成 Base URL 与 API Key；再通过 CC Switch 或 Codex++ 把接口配置给 Codex CLI / Desktop。",
+      },
+      {
+        type: "comparison",
+        title: "推荐路线",
+        columns: ["你的情况", "推荐路线"],
+        rows: [
+          ["单机、个人、多账号", "Cockpit"],
+          ["服务器、多设备、多用户", "Sub2API"],
+          ["已经收到 Base URL + Key", "API endpoint"],
+          ["只使用官方账号且不需要账号池", "官方直接登录"],
+          ["主要使用 Codex CLI", "优先 CC Switch"],
+          ["主要使用 Codex Desktop 且需要中转注入", "优先 Codex++"],
+        ],
+      },
+      {
+        type: "steps",
+        title: "接入前先确认四件事",
+        items: [
+          "账号套餐名称不等于必然拥有 Codex 权限，先到官方页面确认实际权限。",
+          "API 额度商品和直接中转商品不需要先过 Cockpit；只有需要自己做账号池时才考虑 Sub2API。",
+          "Team/K12/Business 席位可能被管理员移除，先确认组织策略和退出路径。",
+          "不把 Cookie、Token 或 Key 上传给本站或聊天机器人。",
+        ],
+      },
+      {
+        type: "callout",
+        tone: "danger",
+        title: "凭证边界",
+        text: CREDENTIAL_WARNING,
+      },
+    ],
+    variants: [
+      variant(
+        "cc-switch",
+        "个人本地路线：Cockpit 或直接 API → CC Switch → Codex",
+        "适合个人电脑、多账号或已有 Base URL + Key 的用户。CC Switch 只保存客户端供应商配置，不代替上游账号池。",
+        {
+          title: "通过 CC Switch 接入 Codex",
+          intro: "先确认商品生效，再选择 Cockpit 或直接 API 作为上游，最后用 CC Switch 配置供应商。",
+          steps: [
+            step(
+              "确认商品已经生效",
+              "在 OpenAI 官方页面核对账号、套餐、席位或 API 额度状态；不要只凭商品标题判断。",
+              "你已确认哪个账号或哪份额度可以使用。",
+              { trouble: "仍显示未生效时先联系原商家处理，不要继续配置第三方客户端。" },
+            ),
+            step(
+              "选择上游并取得 Base URL 与 Key",
+              "个人电脑和多账号选择 Cockpit 本地账号池；已收到 Base URL + Key 的用户直接使用。",
+              "你有一组可用的 Base URL 与对应 Key，且知道协议和模型名。",
+            ),
+            step(
+              "从官方 Release 安装 CC Switch",
+              "只从 farion1231/cc-switch 的 GitHub Releases 页面下载，不要使用陌生网盘或同名收费站点。",
+              "CC Switch 安装完成，版本来源可追溯。",
+              {
+                links: [{ label: "CC Switch 官方仓库", url: "https://github.com/farion1231/cc-switch" }],
+              },
+            ),
+            step(
+              "添加自定义供应商",
+              "打开 Codex 面板，添加自定义供应商，填入上游 Base URL 与客户端 Key；协议按上游当前接口选择，Codex 通常使用 Responses，模型名优先读取 /v1/models 或上游模型列表。",
+              "供应商配置保存成功，Key 只填在客户端本机。",
+              { trouble: "不确定字段名称时，以当前 CC Switch 版本界面显示为准。" },
+            ),
+            step(
+              "启用供应商并重启 Codex",
+              "启用该供应商后重启 Codex CLI / Desktop，使配置和模型目录重新加载。",
+              "Codex 使用新供应商启动，没有继续走旧配置。",
+            ),
+            step(
+              "执行最小测试并可切回官方",
+              "发送一个最小请求，确认上游日志或用量出现记录；同时确认如何切回 OpenAI Official。",
+              "最小请求成功，且你知道随时切回官方线路。",
+            ),
+          ],
+        },
+      ),
+      variant(
+        "codex-plusplus",
+        "服务器或中转注入路线：Sub2API 或直接 API → Codex++ → Codex Desktop",
+        "适合有服务器账号池或需要 Codex Desktop 中转注入的用户。必须通过 Codex++ 启动入口启动 Codex，注入配置才会生效。",
+        {
+          title: "通过 Codex++ 接入 Codex Desktop",
+          intro: "Codex++ 固定指 BigPizzaV3/CodexPlusPlus。先安装官方 Codex Desktop，再安装 Codex++，最后填写中转注入。",
+          steps: [
+            step(
+              "确认商品已经生效",
+              "在 OpenAI 官方页面核对账号、套餐、席位或 API 额度状态。",
+              "你已确认上游可以正常使用。",
+            ),
+            step(
+              "选择上游并取得 Base URL 与用户 Key",
+              "服务器场景使用 Sub2API 的 HTTPS Base URL 与下游用户 Key；已有直接交付的 Base URL + Key 则直接使用。",
+              "你有一组可用的 Base URL 与 Key，且知道协议和模型名。",
+            ),
+            step(
+              "安装官方 Codex Desktop",
+              "先从 OpenAI 官方渠道安装 Codex Desktop，再安装 Codex++ 对应系统版本。",
+              "官方 Codex Desktop 与 Codex++ 都已安装。",
+            ),
+            step(
+              "打开 Codex++ Manager 配置中转注入",
+              "进入中转注入或供应商配置，填写 Base URL 与客户端 Key，选择 OpenAI-compatible / Responses 路径，然后应用配置。",
+              "配置已保存，但还没有启动 Codex。",
+              { trouble: "字段名称随版本变化时，以 Codex++ Manager 当前界面为准。" },
+            ),
+            step(
+              "退出旧 Codex 并通过 Codex++ 启动",
+              "退出已经运行的 Codex，必须从 Codex++ 启动入口重新启动，不能继续用普通桌面快捷方式。",
+              "Codex 通过 Codex++ 启动，注入配置生效。",
+            ),
+            step(
+              "执行最小请求并准备回滚",
+              "发送最小请求确认上游日志出现记录；之后按版本说明清除 API 模式或中转注入，恢复官方线路。",
+              "最小请求成功，且你知道如何恢复官方线路。",
+            ),
+          ],
+        },
+      ),
+    ],
+    verificationChecklist: [
+      "账号、套餐、席位或 API 额度已在官方页面确认生效。",
+      "Cockpit/Sub2API 位于上游，CC Switch/Codex++ 位于客户端侧，两者没有混用。",
+      "Base URL 与 Key 来自对应上游，且 Key 没有被公开。",
+      "CC Switch 与 Codex++ 只选择了其中一条路线，没有同时开启冲突配置。",
+      "最小请求成功，并在上游日志或用量中看到记录。",
+      "关闭第三方路线后可以恢复官方配置。",
+    ],
+    commonProblems: [
+      {
+        problem: "配置后请求返回 401",
+        likelyCause: "Key 错误、Key 未启用或选错了用户 Key。",
+        action: "回到上游管理端重新复制 Key，并检查上游日志中的认证结果。",
+      },
+      {
+        problem: "请求返回 404",
+        likelyCause: "Base URL 缺少 /v1 或协议路径不匹配。",
+        action: "以当前上游页面显示的地址为准，不要使用旧文档中的固定端口。",
+      },
+      {
+        problem: "提示模型不存在",
+        likelyCause: "模型名来自旧教程或版本列表。",
+        action: "读取 /v1/models 或上游当前模型列表，再填回客户端。",
+      },
+      {
+        problem: "套餐显示生效但 Codex 提示无权限",
+        likelyCause: "套餐名称不等于必然拥有 Codex 权限。",
+        action: "查看 OpenAI 官方 Codex 权限说明，并以官方账号页面为准。",
+      },
+    ],
+    riskNotes: [
+      THIRD_PARTY_NOTICE,
+      CREDENTIAL_WARNING,
+      TERMS_RISK_NOTE,
+      "CC Switch 与 Codex++ 通常是二选一；同时安装时需自行管理配置优先级和冲突。",
+      TEAM_SEAT_WARNING,
+    ],
+    faq: [
+      {
+        question: "必须同时安装 CC Switch 和 Codex++ 吗？",
+        answer: "不需要。CC Switch 与 Codex++ 通常是二选一：主要用 Codex CLI 优先 CC Switch，主要用 Codex Desktop 且需要中转注入优先 Codex++。",
+      },
+      {
+        question: "账号显示 Plus 就一定能用 Codex 吗？",
+        answer: "不一定。套餐名称不等于必然拥有 Codex 权限，必须看 OpenAI 官方账号页面和 Codex 权限说明。",
+      },
+      {
+        question: "API 额度商品需要先导入 Cockpit 吗？",
+        answer: "不需要。API 额度商品和直接中转商品可以直接走“Base URL + API Key → CC Switch 或 Codex++”路线。",
+      },
+      {
+        question: "Team/K12 席位会被管理员撤销吗？",
+        answer: "会。工作区管理员可以限制或移除席位，不要在第三方管理的工作区或未授权账号池中处理敏感信息。",
+      },
+    ],
+    sources: [
+      OFFICIAL_SOURCES.openaiCodexConfig,
+      OFFICIAL_SOURCES.openaiCodexCli,
+      PROJECT_SOURCES.cockpitTools,
+      PROJECT_SOURCES.sub2api,
+      PROJECT_SOURCES.ccSwitch,
+      PROJECT_SOURCES.codexPlusPlus,
+    ],
+    lastReviewedAt: LAST_REVIEWED_AT,
+  },
+  {
+    slug: "cockpit-to-codex",
+    title: "Cockpit 接入 CC Switch 或 Codex++ 使用 Codex",
+    description:
+      "在个人电脑上用 Cockpit Tools 管理 OpenAI 账号并启动本地 API 服务，再把 Base URL 与客户端 Key 配置给 CC Switch 或 Codex++，接入 Codex。",
+    flow: ["OpenAI 账号或 JSON", "Cockpit 本地账号池", "CC Switch / Codex++", "Codex"],
+    audience: [
+      "个人电脑、单机用户",
+      "有多个 OpenAI 账号需要本地管理的用户",
+      "收到 JSON、OAuth 或 API Key 交付后需要导入 Cockpit 的用户",
+    ],
+    prerequisites: [
+      "已安装 Cockpit Tools，且安装来源为项目官方 Release。",
+      "已确认账号、套餐或席位可用。",
+      "若收到 JSON，可先使用 /tools/json-to-cockpit 完成本地转换。",
+      "本地端口未被占用，且用户知道真实 Base URL 和客户端 Key。",
+    ],
+    overview: [
+      {
+        type: "paragraph",
+        text: "Cockpit Tools 是本地账号管理和本地 API 服务，属于上游；CC Switch 和 Codex++ 是客户端侧配置，属于下游。先完成账号导入和 API 服务启动，再配置 CC Switch 或 Codex++，不能把下游配置放在账号导入前。",
+      },
+      {
+        type: "steps",
+        title: "Cockpit 共同步骤",
+        items: [
+          "打开 Cockpit Tools。",
+          "左侧选择 Codex。",
+          "点击右上角 +。",
+          "根据交付选择：OAuth 授权、Token / JSON、API Key 或导入。",
+          "检查账号邮箱、套餐和额度。",
+          "把目标账号加入 Cockpit API 服务账号池。",
+          "启动本地 API 服务。",
+          "创建或复制客户端 Key。",
+          "复制 Base URL，以你当前 Cockpit API 服务页面显示的地址为准。",
+          "先通过模型列表或最小请求确认服务可用。",
+          "再进入 CC Switch 或 Codex++。",
+        ],
+      },
+      {
+        type: "callout",
+        tone: "info",
+        title: "添加 Codex 账号的四种方式",
+        text: "OAuth 授权用于在浏览器中登录 OpenAI 账号并完成授权；Token / JSON 用于手动粘贴单账号 Token 或 JSON；API Key 用于直接交付可用的 Key；导入用于读取 Cockpit 支持的账号导出文件。商家交付 CPA、Sub2 或其他非 Cockpit JSON 时，先使用 /tools/json-to-cockpit 转换。",
+      },
+      {
+        type: "callout",
+        tone: "warning",
+        title: "OAuth 回调只粘贴到 Cockpit",
+        text: "不要在教程截图、日志或售后信息中展示完整 Token、回调 code、state 或 API Key。OAuth 回调地址只粘贴到 Cockpit 自己的输入框，不上传到本站或聊天机器人。",
+      },
+      {
+        type: "callout",
+        tone: "danger",
+        title: "凭证边界",
+        text: `${CREDENTIAL_WARNING}${LOCAL_CONVERTER_NOTE}`,
+      },
+    ],
+    variants: [
+      variant(
+        "cc-switch",
+        "方案 A：Cockpit → CC Switch → Codex",
+        "CC Switch 负责供应商配置、切换和本地路由，消费 Cockpit 提供的 Base URL 与客户端 Key。",
+        {
+          title: "把 Cockpit 接口配置到 CC Switch",
+          intro: `从 Cockpit 复制 Base URL 与客户端 Key 后，再按顺序配置 CC Switch。${UI_VERSION_NOTE}`,
+          steps: [
+            step(
+              "从官方 Release 安装 CC Switch",
+              "只从 farion1231/cc-switch 的 GitHub Releases 页面下载对应系统版本。",
+              "CC Switch 安装完成。",
+              {
+                links: [{ label: "CC Switch Releases", url: "https://github.com/farion1231/cc-switch/releases" }],
+              },
+            ),
+            step(
+              "打开 Codex 面板",
+              "在 CC Switch 中打开 Codex 面板，准备添加自定义供应商。",
+              "你已进入 Codex 供应商管理界面。",
+            ),
+            step(
+              "添加自定义供应商",
+              "点击添加自定义供应商，填写供应商名称。",
+              "新供应商卡片已创建。",
+            ),
+            step(
+              "填入 Cockpit Base URL",
+              "粘贴从 Cockpit API 服务页面复制的 Base URL。正文不硬编码端口，以你当前 Cockpit 页面显示的地址为准。",
+              "Base URL 已填写，路径是否包含 /v1 以当前页面为准。",
+            ),
+            step(
+              "填入 Cockpit 客户端 Key",
+              "粘贴 Cockpit 生成的客户端 Key，不要把真实 Key 发到公开渠道。",
+              "客户端 Key 已保存到本机配置。",
+              { trouble: "Key 丢失时回到 Cockpit 重新创建或复制，不要在旧截图里找。" },
+            ),
+            step(
+              "选择协议",
+              "协议按 Cockpit 当前接口选择，Codex 通常使用 Responses。",
+              "协议与上游当前接口一致。",
+            ),
+            step(
+              "填写模型名",
+              "模型名优先读取 /v1/models 或 Cockpit 当前模型列表，不要使用旧教程的固定值。",
+              "模型名来自当前可用列表。",
+            ),
+            step(
+              "启用供应商",
+              "把该供应商设为启用状态。",
+              "供应商已启用。",
+            ),
+            step(
+              "重启 Codex CLI / Desktop",
+              "重启 Codex CLI 或 Codex Desktop，使配置和模型目录重新加载。",
+              "Codex 已加载新供应商配置。",
+            ),
+            step(
+              "执行最小测试",
+              "发送一个最小请求，确认 Cockpit 日志或用量出现记录。",
+              "最小请求成功，且上游出现对应记录。",
+            ),
+            step(
+              "知道如何切回 OpenAI Official",
+              "确认 CC Switch 中切换回 OpenAI Official 的方法，并记录当前配置。",
+              "关闭第三方路线后可恢复官方配置。",
+              {
+                items: [
+                  "若当前 CC Switch 版本提供“保留官方登录”或“Codex App 增强”选项，只有需要同时保留官方插件/远程能力时才开启。",
+                  "不要假设所有版本的开关名称和默认值相同。",
+                ],
+              },
+            ),
+          ],
+        },
+      ),
+      variant(
+        "codex-plusplus",
+        "方案 B：Cockpit → Codex++ → Codex Desktop",
+        "Codex++ 固定指 BigPizzaV3/CodexPlusPlus，通过中转注入把 Codex Desktop 请求指向 Cockpit 的 Base URL 与客户端 Key。",
+        {
+          title: "把 Cockpit 接口配置到 Codex++",
+          intro: "必须从 Codex++ 启动入口启动 Codex，相关增强和中转配置才会生效。",
+          steps: [
+            step(
+              "确认项目来源",
+              "Codex++ 固定使用 BigPizzaV3/CodexPlusPlus，从官方仓库或官方 Release 获取。",
+              "你已确认使用正确的项目，而不是同名 loader 项目。",
+              {
+                links: [{ label: "CodexPlusPlus 官方仓库", url: "https://github.com/BigPizzaV3/CodexPlusPlus" }],
+              },
+            ),
+            step(
+              "安装官方 Codex Desktop",
+              "先从 OpenAI 官方渠道安装 Codex Desktop。",
+              "官方 Codex Desktop 已安装。",
+            ),
+            step(
+              "安装 Codex++ 对应系统版本",
+              "按操作系统和架构选择 Codex++ 对应版本完成安装。",
+              "Codex++ 安装完成，可打开 Codex++ Manager。",
+            ),
+            step(
+              "打开 Codex++ Manager",
+              "启动 Codex++ Manager，进入中转注入或供应商配置。",
+              "你已进入配置界面。",
+            ),
+            step(
+              "填写 Cockpit Base URL 与客户端 Key",
+              "粘贴 Cockpit API 服务页面显示的 Base URL 与客户端 Key，字段名称以当前版本为准。",
+              "配置已填写，没有使用固定端口或旧字段名。",
+            ),
+            step(
+              "选择 OpenAI-compatible / Responses 路径",
+              "按 Cockpit 当前接口选择路径，Codex 通常使用 Responses。",
+              "路径与上游接口一致。",
+            ),
+            step(
+              "应用配置",
+              "保存并应用中转注入配置。",
+              "配置已生效并等待重启。",
+            ),
+            step(
+              "退出已经运行的 Codex",
+              "完全退出当前运行的 Codex，避免旧进程继续占用配置。",
+              "没有正在运行的旧 Codex 进程。",
+            ),
+            step(
+              "通过 Codex++ 启动 Codex",
+              "必须使用 Codex++ 的启动入口重新启动 Codex，不要用普通桌面快捷方式。",
+              "Codex 已通过 Codex++ 启动，注入配置生效。",
+            ),
+            step(
+              "执行最小请求",
+              "发送一个最小请求，确认 Cockpit 日志或用量出现记录。",
+              "最小请求成功，且上游出现对应记录。",
+            ),
+            step(
+              "准备回滚",
+              "按版本说明清除 API 模式或中转注入，恢复官方线路。",
+              "你知道如何恢复官方配置。",
+            ),
+          ],
+        },
+      ),
+    ],
+    verificationChecklist: [
+      "Cockpit 账号状态正常。",
+      "API 服务在运行。",
+      "Base URL 可访问。",
+      "Key 未被公开。",
+      "/v1/models 或模型列表正常。",
+      "Codex 请求出现在 Cockpit 日志或用量中。",
+      "实际扣减的是目标账号或账号池额度。",
+      "关闭第三方路线后可恢复官方配置。",
+    ],
+    commonProblems: [
+      {
+        problem: "API 服务没有启动",
+        likelyCause: "账号池为空或服务状态未运行。",
+        action: "回到 Cockpit API 服务页面确认账号已加入并启动服务。",
+      },
+      {
+        problem: "填入 Base URL 后请求失败",
+        likelyCause: "端口或 /v1 路径来自旧教程。",
+        action: "以 Cockpit 当前 API 服务页面显示的地址为准，不要硬编码端口。",
+      },
+      {
+        problem: "客户端 Key 无效",
+        likelyCause: "复制了账号 Token 而不是客户端 Key。",
+        action: "在 Cockpit 中创建或复制客户端 Key，只把 Key 给本机客户端。",
+      },
+      {
+        problem: "模型列表为空",
+        likelyCause: "账号池中没有可用账号或账号被限制。",
+        action: "检查账号状态、套餐、额度和筛选条件。",
+      },
+    ],
+    riskNotes: [
+      THIRD_PARTY_NOTICE,
+      CREDENTIAL_WARNING,
+      LOCAL_CONVERTER_NOTE,
+      TERMS_RISK_NOTE,
+      "Cockpit 本地 API 服务只应在本机使用；不要把 Base URL 与客户端 Key 分享给陌生人。",
+    ],
+    faq: [
+      {
+        question: "Cockpit 和 CC Switch 是同一个工具吗？",
+        answer: "不是。Cockpit 是本地账号池和 API 服务（上游），CC Switch 是客户端供应商切换（下游），两者职责不同。",
+      },
+      {
+        question: "端口必须使用 12178 吗？",
+        answer: "不一定。正文不硬编码永久端口，以你当前 Cockpit API 服务页面显示的地址为准。",
+      },
+      {
+        question: "收到的 JSON 不是 Cockpit 格式怎么办？",
+        answer: "先使用本站 /tools/json-to-cockpit 在浏览器本地完成转换，再导入 Cockpit；不要把原文件交给陌生人。",
+      },
+      {
+        question: "本地 API 服务会公开我的账号吗？",
+        answer: "Cockpit 是本地工具，但仍要保管好 Base URL 与客户端 Key；不要把本地地址和 Key 上传到公开渠道。",
+      },
+    ],
+    sources: [
+      OFFICIAL_SOURCES.openaiCodexConfig,
+      PROJECT_SOURCES.cockpitTools,
+      PROJECT_SOURCES.ccSwitch,
+      PROJECT_SOURCES.codexPlusPlus,
+    ],
+    lastReviewedAt: LAST_REVIEWED_AT,
+  },
+  {
+    slug: "sub2api-to-codex",
+    title: "Sub2API 接入 CC Switch 或 Codex++ 使用 Codex",
+    description:
+      "在服务器上部署 Sub2API 账号池并分发下游用户 Key，再把 HTTPS Base URL 与用户 Key 配置给 CC Switch 或 Codex++，接入 Codex。",
+    flow: ["OpenAI 账号", "Sub2API 服务器账号池", "CC Switch / Codex++", "Codex"],
+    audience: [
+      "有服务器和运维能力的用户",
+      "多设备、多用户或需要账号池调度的团队",
+      "已经部署 Sub2API 并登录管理端的用户",
+    ],
+    prerequisites: [
+      "已有服务器、域名和运维能力。",
+      "理解 HTTPS、数据库、日志与密钥管理。",
+      "已按 Sub2API 官方 README 部署并登录管理端。",
+      "账号池中至少有一个健康可用的 OpenAI 账号。",
+    ],
+    overview: [
+      {
+        type: "callout",
+        tone: "warning",
+        title: "高级方案",
+        text: "高级方案：需要服务器、HTTPS、数据库、日志和密钥管理能力。个人单机用户优先选择 Cockpit。",
+      },
+      {
+        type: "paragraph",
+        text: "Sub2API 是服务端账号池，不是桌面客户端，也不是普通单机用户的首选。部署时只依赖稳定概念：Linux/容器环境、数据库与缓存、HTTPS、管理员账号和数据备份。不要复制可能过时的完整部署命令，以项目官方 README 和部署文档为准。",
+      },
+      {
+        type: "steps",
+        title: "部署与账号池共同步骤",
+        items: [
+          "部署并登录 Sub2API 管理端。",
+          "添加 OpenAI/Codex 账号。",
+          "选择 OAuth 或项目当前支持的导入方式。",
+          "核对账号状态、套餐、额度和失败原因。",
+          "创建账号组或账号池。",
+          "配置调度、并发和禁用规则。",
+          "创建下游用户或 API Key。",
+          "仅把用户 Key 提供给客户端，不要把管理员 Key 发给用户。",
+          "复制 HTTPS Base URL。",
+          "用最小请求检查 /v1/models 和 /v1/responses。",
+          "再配置 CC Switch 或 Codex++。",
+        ],
+      },
+      {
+        type: "callout",
+        tone: "danger",
+        title: "管理员 Key 与用户 Key 分离",
+        text: "管理员 Key 只能保留在服务器管理端；客户端只使用下游用户 Key。服务器应限制来源、并发和额度，且不要把示例管理员密钥或数据库密码写进任何页面。",
+      },
+    ],
+    variants: [
+      variant(
+        "cc-switch",
+        "方案 A：Sub2API → CC Switch → Codex",
+        "CC Switch 只保存客户端配置，不代替服务器权限控制；Base URL 是远程 HTTPS 地址，API Key 是下游用户 Key。",
+        {
+          title: "把 Sub2API 接口配置到 CC Switch",
+          intro: "步骤与 Cockpit 方案相近，但必须使用远程 HTTPS Base URL 和下游用户 Key。",
+          steps: [
+            step(
+              "从官方 Release 安装 CC Switch",
+              "只从 farion1231/cc-switch 的 GitHub Releases 页面下载对应系统版本。",
+              "CC Switch 安装完成。",
+              {
+                links: [{ label: "CC Switch Releases", url: "https://github.com/farion1231/cc-switch/releases" }],
+              },
+            ),
+            step(
+              "打开 Codex 面板并添加自定义供应商",
+              "在 CC Switch 中打开 Codex 面板，添加自定义供应商。",
+              "新供应商卡片已创建。",
+            ),
+            step(
+              "填入 Sub2API HTTPS Base URL",
+              "粘贴 Sub2API 管理端提供的远程 HTTPS Base URL，不填写本地地址。",
+              "Base URL 是远程 HTTPS 地址。",
+            ),
+            step(
+              "填入下游用户 Key",
+              "粘贴 Sub2API 下游用户 Key，不能使用管理员 Key。",
+              "客户端只持有用户 Key。",
+              { trouble: "拿到管理员 Key 时先撤销并重新签发，不要把管理员 Key 配到客户端。" },
+            ),
+            step(
+              "选择协议并填写模型名",
+              "协议按 Sub2API 当前接口选择，Codex 通常使用 Responses；模型名以 /v1/models 或管理端模型列表为准。",
+              "协议和模型名与服务器当前接口一致。",
+            ),
+            step(
+              "启用供应商并重启 Codex",
+              "启用供应商后重启 Codex CLI / Desktop。",
+              "Codex 已加载新供应商配置。",
+            ),
+            step(
+              "执行最小请求",
+              "发送最小请求，确认服务器调度日志显示请求落到预期账号池。",
+              "最小请求成功，服务器日志出现对应记录。",
+            ),
+            step(
+              "知道如何切回官方",
+              "确认 CC Switch 中切换回 OpenAI Official 的方法。",
+              "关闭第三方路线后可恢复官方配置。",
+            ),
+          ],
+        },
+      ),
+      variant(
+        "codex-plusplus",
+        "方案 B：Sub2API → Codex++ → Codex Desktop",
+        "Codex++ 固定指 BigPizzaV3/CodexPlusPlus；在中转注入中填写 Sub2API HTTPS Base URL 与下游用户 Key，并通过 Codex++ 启动。",
+        {
+          title: "把 Sub2API 接口配置到 Codex++",
+          intro: "远程服务不可用时应先检查服务器、域名、TLS 和账号池，不要反复重装 Codex。",
+          steps: [
+            step(
+              "确认项目来源",
+              "从 BigPizzaV3/CodexPlusPlus 官方仓库或官方 Release 获取 Codex++。",
+              "你已确认使用正确的项目。",
+              {
+                links: [{ label: "CodexPlusPlus 官方仓库", url: "https://github.com/BigPizzaV3/CodexPlusPlus" }],
+              },
+            ),
+            step(
+              "安装官方 Codex Desktop 与 Codex++",
+              "先安装官方 Codex Desktop，再按系统版本安装 Codex++。",
+              "两个程序都已安装。",
+            ),
+            step(
+              "打开 Codex++ Manager 进入中转注入",
+              "启动 Codex++ Manager，进入中转注入或供应商配置。",
+              "你已进入配置界面。",
+            ),
+            step(
+              "填写 Sub2API HTTPS Base URL",
+              "粘贴远程 HTTPS Base URL，不填写本地地址或旧示例端口。",
+              "Base URL 已填写。",
+            ),
+            step(
+              "填写下游用户 Key",
+              "粘贴下游用户 Key，不要使用管理员 Key。",
+              "客户端只持有用户 Key。",
+            ),
+            step(
+              "选择路径并应用配置",
+              "选择 OpenAI-compatible / Responses 路径并应用配置。",
+              "配置已保存。",
+            ),
+            step(
+              "退出旧 Codex 并通过 Codex++ 启动",
+              "退出已经运行的 Codex，从 Codex++ 启动入口重新启动 Codex Desktop。",
+              "Codex 已通过 Codex++ 启动，注入配置生效。",
+            ),
+            step(
+              "执行最小请求",
+              "发送最小请求，确认请求到达服务器账号池。",
+              "最小请求成功，服务器日志出现记录。",
+            ),
+            step(
+              "远程故障时先查服务器",
+              "服务不可用时依次检查服务器、域名、TLS 和账号池，不要反复重装 Codex。",
+              "你按服务器链路排查，而不是重装客户端。",
+            ),
+            step(
+              "清除中转注入恢复官方",
+              "按版本说明清除中转注入，恢复官方线路。",
+              "你已知道如何回滚。",
+            ),
+          ],
+        },
+      ),
+    ],
+    verificationChecklist: [
+      "HTTPS 证书正常。",
+      "管理端未暴露给普通用户。",
+      "用户 Key 权限和额度符合预期。",
+      "账号池至少有一个健康账号。",
+      "调度日志显示请求落到预期账号。",
+      "客户端看不到管理员密钥。",
+      "请求失败不会把完整凭证写入公开日志。",
+    ],
+    commonProblems: [
+      {
+        problem: "客户端请求 401",
+        likelyCause: "使用了管理员 Key，或用户 Key 已失效。",
+        action: "改用下游用户 Key，必要时重新签发并撤销旧 Key。",
+      },
+      {
+        problem: "HTTPS 证书告警",
+        likelyCause: "证书过期、域名不匹配或使用自签名证书。",
+        action: "先修复域名、TLS 和证书链，再继续配置客户端。",
+      },
+      {
+        problem: "账号池没有健康账号",
+        likelyCause: "账号被禁用、额度用完或调度规则排除了全部账号。",
+        action: "在管理端查看账号状态、额度和失败原因。",
+      },
+      {
+        problem: "请求没有到达服务器",
+        likelyCause: "客户端走了旧配置、DNS 或网络问题。",
+        action: "检查客户端供应商配置、域名解析和防火墙，不要重装 Codex。",
+      },
+    ],
+    riskNotes: [
+      THIRD_PARTY_NOTICE,
+      CREDENTIAL_WARNING,
+      TERMS_RISK_NOTE,
+      "Sub2API 是服务端账号池，不是桌面客户端；普通单机用户优先选择 Cockpit。",
+      "管理员 Key 和数据库凭据必须与用户 Key 分离，防止客户端看到服务器管理权限。",
+      TEAM_SEAT_WARNING,
+    ],
+    faq: [
+      {
+        question: "Sub2API 能当作普通桌面客户端使用吗？",
+        answer: "不能。Sub2API 是服务端账号池和 API 分发服务，需要服务器、HTTPS、数据库和运维能力。",
+      },
+      {
+        question: "管理员 Key 和用户 Key 有什么区别？",
+        answer: "管理员 Key 管理整个服务，只能保留在服务器管理端；用户 Key 只代表下游用户的权限和额度，客户端只应拿到用户 Key。",
+      },
+      {
+        question: "可以复制旧版部署命令直接执行吗？",
+        answer: "不要。部署命令可能过时，应以 Sub2API 官方 README 和部署文档为准，且不把示例管理员密钥或数据库密码写进页面。",
+      },
+      {
+        question: "远程服务不可用为什么要先查服务器？",
+        answer: "远程链路涉及服务器、域名、TLS、账号池和日志，反复重装 Codex 不会解决上游问题。",
+      },
+    ],
+    sources: [
+      OFFICIAL_SOURCES.openaiCodexConfig,
+      PROJECT_SOURCES.sub2api,
+      PROJECT_SOURCES.ccSwitch,
+      PROJECT_SOURCES.codexPlusPlus,
+    ],
+    lastReviewedAt: LAST_REVIEWED_AT,
+  },
+  {
+    slug: "api-endpoint-to-codex",
+    title: "把 Base URL 和 API Key 接入 CC Switch 或 Codex++",
+    description:
+      "已有 Base URL 与 API Key 时，不需要先导入 Cockpit 或部署 Sub2API，直接通过 CC Switch 或 Codex++ 把接口配置给 Codex。",
+    flow: ["Base URL + API Key", "CC Switch / Codex++", "Codex"],
+    audience: [
+      "已有 OpenAI API 额度的开发者",
+      "购买了直接交付中转地址和用户 Key 商品的用户",
+      "不需要账号池、只需要把接口配置给 Codex 的用户",
+    ],
+    prerequisites: [
+      "已收到 Base URL、API Key、协议、模型名、额度和并发信息。",
+      "已确认 Key 只交给可信任的客户端。",
+      "已安装 Codex CLI 或 Codex Desktop。",
+    ],
+    overview: [
+      {
+        type: "paragraph",
+        text: "本路线不要求先导入 Cockpit，也不要求先部署 Sub2API。适用商品包括 openai-api-credit、chatgpt-access-service，以及明确交付中转地址和用户 Key 的商品。",
+      },
+      {
+        type: "steps",
+        title: "接入前先确认五项信息",
+        items: [
+          "Base URL：是否包含 /v1，以供应商交付为准。",
+          "API Key：属于哪个下游用户，是否有有效期和额度。",
+          "支持的协议：Responses 或 OpenAI-compatible。",
+          "模型名：从 /v1/models 或供应商控制台读取。",
+          "额度与并发：避免超限后误判为客户端问题。",
+        ],
+      },
+      {
+        type: "callout",
+        tone: "warning",
+        title: "不要把 Key 写进公开位置",
+        text: "不把第三方 Key 写入公开仓库、前端代码或截图。供应商配置只保存在客户端本机。",
+      },
+      {
+        type: "callout",
+        tone: "info",
+        title: "常见状态码排查",
+        text: "出现 401 时先检查 Key；404 先检查路径和协议；模型不存在先查模型列表，不要反复重装客户端。",
+      },
+    ],
+    variants: [
+      variant(
+        "cc-switch",
+        "方案 A：Base URL + Key → CC Switch → Codex",
+        "CC Switch 管理供应商配置和切换，适合主要使用 Codex CLI 或需要快速切换供应商的用户。",
+        {
+          title: "把 Base URL 与 Key 配置到 CC Switch",
+          intro: "直接从官方 Release 安装 CC Switch，然后按顺序添加供应商。",
+          steps: [
+            step(
+              "从官方 Release 安装 CC Switch",
+              "只从 farion1231/cc-switch 的 GitHub Releases 页面下载。",
+              "CC Switch 安装完成。",
+              {
+                links: [{ label: "CC Switch Releases", url: "https://github.com/farion1231/cc-switch/releases" }],
+              },
+            ),
+            step(
+              "打开 Codex 面板并添加自定义供应商",
+              "在 CC Switch 中打开 Codex 面板，添加自定义供应商。",
+              "新供应商卡片已创建。",
+            ),
+            step(
+              "填入 Base URL",
+              "粘贴供应商交付的 Base URL；是否包含 /v1 以供应商交付说明为准。",
+              "Base URL 已填写。",
+            ),
+            step(
+              "填入 API Key",
+              "粘贴对应 Key，不要把 Key 发到公开渠道。",
+              "Key 已保存到本机配置。",
+            ),
+            step(
+              "选择协议",
+              "选择 Responses 或 OpenAI-compatible，以供应商支持为准。",
+              "协议与供应商一致。",
+            ),
+            step(
+              "填写模型名",
+              "模型名以 /v1/models 或供应商控制台为准。",
+              "模型名来自当前可用列表。",
+            ),
+            step(
+              "启用供应商并重启 Codex",
+              "启用供应商后重启 Codex CLI / Desktop。",
+              "Codex 已加载新供应商配置。",
+            ),
+            step(
+              "执行最小请求",
+              "发送一个最小请求，确认模型可用和额度扣减符合预期。",
+              "最小请求成功。",
+            ),
+            step(
+              "知道如何切回官方",
+              "确认 CC Switch 中切换回 OpenAI Official 的方法。",
+              "你知道如何恢复官方配置。",
+            ),
+          ],
+        },
+      ),
+      variant(
+        "codex-plusplus",
+        "方案 B：Base URL + Key → Codex++ → Codex Desktop",
+        "Codex++ 固定指 BigPizzaV3/CodexPlusPlus，适合 Codex Desktop 中转注入；必须通过 Codex++ 启动入口启动。",
+        {
+          title: "把 Base URL 与 Key 配置到 Codex++",
+          intro: "先安装官方 Codex Desktop，再安装 Codex++，最后在中转注入中填写配置。",
+          steps: [
+            step(
+              "从官方仓库获取 Codex++",
+              "固定使用 BigPizzaV3/CodexPlusPlus，从官方仓库或官方 Release 获取。",
+              "你已确认项目来源正确。",
+              {
+                links: [{ label: "CodexPlusPlus 官方仓库", url: "https://github.com/BigPizzaV3/CodexPlusPlus" }],
+              },
+            ),
+            step(
+              "安装官方 Codex Desktop 与 Codex++",
+              "先安装官方 Codex Desktop，再按系统版本安装 Codex++。",
+              "两个程序都已安装。",
+            ),
+            step(
+              "打开 Codex++ Manager",
+              "启动 Codex++ Manager，进入中转注入或供应商配置。",
+              "你已进入配置界面。",
+            ),
+            step(
+              "填写 Base URL 与 API Key",
+              "粘贴供应商交付的 Base URL 与对应 Key。",
+              "配置已填写。",
+            ),
+            step(
+              "选择路径并应用配置",
+              "选择 OpenAI-compatible / Responses 路径并应用。",
+              "配置已保存。",
+            ),
+            step(
+              "退出旧 Codex 并通过 Codex++ 启动",
+              "退出已经运行的 Codex，从 Codex++ 启动入口重新启动。",
+              "Codex 已通过 Codex++ 启动，注入配置生效。",
+            ),
+            step(
+              "执行最小请求",
+              "发送最小请求，确认模型和额度正常。",
+              "最小请求成功。",
+            ),
+            step(
+              "清除 API 模式恢复官方",
+              "按版本说明清除 API 模式或中转注入，恢复官方线路。",
+              "你已知道如何回滚。",
+            ),
+          ],
+        },
+      ),
+    ],
+    verificationChecklist: [
+      "最小请求成功，模型响应符合预期。",
+      "模型列表可读取。",
+      "额度或扣量记录与供应商说明一致。",
+      "Key 未写入公开仓库、前端代码或截图。",
+      "关闭第三方路线后可恢复官方配置。",
+    ],
+    commonProblems: [
+      {
+        problem: "401 Unauthorized",
+        likelyCause: "API Key 错误、过期或不属于该端点。",
+        action: "先检查 Key，回到供应商控制台重新复制或重新签发。",
+      },
+      {
+        problem: "404 Not Found",
+        likelyCause: "Base URL 路径或协议不匹配。",
+        action: "检查路径是否包含 /v1，并核对 Responses / OpenAI-compatible 协议。",
+      },
+      {
+        problem: "模型不存在",
+        likelyCause: "模型名来自旧文档。",
+        action: "读取 /v1/models 或供应商控制台，填写当前模型名。",
+      },
+      {
+        problem: "触发额度或并发限制",
+        likelyCause: "超出供应商设定的额度与并发。",
+        action: "查看供应商控制台的额度、并发和错误码，不要误判为客户端问题。",
+      },
+    ],
+    riskNotes: [
+      THIRD_PARTY_NOTICE,
+      CREDENTIAL_WARNING,
+      TERMS_RISK_NOTE,
+      "此商品直接交付 API 使用能力，不需要先把账号导入 Cockpit；只有需要自行做账号池时才考虑 Sub2API。",
+    ],
+    faq: [
+      {
+        question: "使用这个路线需要先安装 Cockpit 吗？",
+        answer: "不需要。已经有 Base URL + API Key 时，直接通过 CC Switch 或 Codex++ 配置给 Codex 即可。",
+      },
+      {
+        question: "Base URL 一定要带 /v1 吗？",
+        answer: "以供应商交付说明为准。有的供应商自带 /v1，有的需要手动加上，不要按旧教程硬编码。",
+      },
+      {
+        question: "API Key 可以写进前端代码吗？",
+        answer: "不可以。Key 只应保存在可信任客户端或密钥管理环境中，不能进入公开仓库、前端代码或截图。",
+      },
+      {
+        question: "第三方中转稳定吗？",
+        answer: "不承诺稳定、永久或不会封号。中转服务可能受平台条款、组织政策、地区、网络环境和风控限制。",
+      },
+    ],
+    sources: [
+      OFFICIAL_SOURCES.openaiCodexConfig,
+      PROJECT_SOURCES.ccSwitch,
+      PROJECT_SOURCES.codexPlusPlus,
+    ],
+    lastReviewedAt: LAST_REVIEWED_AT,
+  },
+] satisfies readonly WorkflowGuide[];

--- a/apps/web/lib/guides/registry.ts
+++ b/apps/web/lib/guides/registry.ts
@@ -2,6 +2,7 @@ import { brandGuideEntries } from "@/content/guides/brands";
 import { deliveryGuideEntries } from "@/content/guides/delivery";
 import { generalGuideEntries } from "@/content/guides/general";
 import { productGuideEntries } from "@/content/guides/products";
+import { workflowGuideEntries } from "@/content/guides/workflows";
 import type {
   BrandGuide,
   BrandSlug,
@@ -12,6 +13,8 @@ import type {
   KnownDeliveryType,
   ProductGuide,
   ProductSlug,
+  WorkflowGuide,
+  WorkflowGuideSlug,
 } from "./types";
 import { validateGuideRegistry } from "./validation";
 
@@ -29,12 +32,14 @@ export const brandGuides: Readonly<Record<BrandSlug, BrandGuide>> = indexBy(bran
 export const productGuides: Readonly<Record<ProductSlug, ProductGuide>> = indexBy(productGuideEntries, (guide) => guide.productSlug, "product guide");
 export const deliveryGuides: Readonly<Record<KnownDeliveryType, DeliveryGuide>> = indexBy(deliveryGuideEntries, (guide) => guide.deliveryType, "delivery guide");
 export const generalGuides: Readonly<Record<GeneralGuideSlug, GeneralGuide>> = indexBy(generalGuideEntries, (guide) => guide.slug, "general guide");
+export const workflowGuides: Readonly<Record<WorkflowGuideSlug, WorkflowGuide>> = indexBy(workflowGuideEntries, (guide) => guide.slug, "workflow guide");
 
 export const guideRegistry: GuideRegistry = {
   brands: brandGuides,
   products: productGuides,
   delivery: deliveryGuides,
   general: generalGuides,
+  workflows: workflowGuides,
 };
 
 validateGuideRegistry(guideRegistry);
@@ -53,4 +58,10 @@ export function getDeliveryGuide(type?: string | null): DeliveryGuide | undefine
 
 export function getGeneralGuide(slug?: string | null): GeneralGuide | undefined {
   return slug ? generalGuides[slug as GeneralGuideSlug] : undefined;
+}
+
+export function getWorkflowGuide(
+  slug?: string | null,
+): WorkflowGuide | undefined {
+  return slug ? workflowGuides[slug as WorkflowGuideSlug] : undefined;
 }

--- a/apps/web/lib/guides/types.ts
+++ b/apps/web/lib/guides/types.ts
@@ -45,6 +45,90 @@ export const PRODUCT_SLUGS = [
 
 export type ProductSlug = (typeof PRODUCT_SLUGS)[number];
 
+export const WORKFLOW_GUIDE_SLUGS = [
+  "openai-codex",
+  "cockpit-to-codex",
+  "sub2api-to-codex",
+  "api-endpoint-to-codex",
+] as const;
+
+export type WorkflowGuideSlug = (typeof WORKFLOW_GUIDE_SLUGS)[number];
+
+export type WorkflowRelevance =
+  | "recommended"
+  | "conditional"
+  | "advanced";
+
+export interface ProductWorkflowReference {
+  workflowSlug: WorkflowGuideSlug;
+  relevance: WorkflowRelevance;
+
+  /**
+   * 用户满足什么条件时选择此路线。
+   * 必填，不允许仅写“视情况而定”。
+   */
+  condition: string;
+
+  /**
+   * 卡片中显示的目标用户。
+   */
+  audience: string;
+
+  /**
+   * 产品特有警告。例如 Team/K12 管理员可撤销席位。
+   */
+  note?: string;
+}
+
+export type WorkflowVariantId = "cc-switch" | "codex-plusplus";
+
+export interface WorkflowVariant {
+  id: WorkflowVariantId;
+  title: string;
+  description: string;
+  walkthrough: GuideWalkthrough;
+}
+
+export interface WorkflowProblem {
+  problem: string;
+  likelyCause: string;
+  action: string;
+}
+
+export interface WorkflowGuide {
+  slug: WorkflowGuideSlug;
+  title: string;
+  description: string;
+
+  /**
+   * 用于卡片直接展示链路，例如：
+   * ["OpenAI 账号", "Cockpit", "CC Switch / Codex++", "Codex"]
+   */
+  flow: readonly string[];
+
+  audience: readonly string[];
+  prerequisites: readonly string[];
+  overview: readonly GuideBlock[];
+
+  /**
+   * 详细页中分别展示 CC Switch 和 Codex++ 两个方案。
+   * 不做 Tab；使用两个独立 section，方便 SEO 和无 JS 阅读。
+   */
+  variants: readonly WorkflowVariant[];
+
+  verificationChecklist: readonly string[];
+  commonProblems: readonly WorkflowProblem[];
+  riskNotes: readonly string[];
+  faq: readonly GuideFaq[];
+
+  /**
+   * OpenAI 官方文档和第三方项目自己的官方仓库都可以放入，
+   * 但必须通过 source.kind 明确区分。
+   */
+  sources: readonly GuideSource[];
+  lastReviewedAt: string;
+}
+
 export const GENERAL_GUIDE_SLUGS = [
   "buying-checklist",
   "account-control",
@@ -97,12 +181,22 @@ export interface GuideWalkthrough {
   steps: readonly GuideWalkthroughStep[];
 }
 
-export interface OfficialSource {
+export type GuideSourceKind =
+  | "platform_official"
+  | "project_official";
+
+export interface GuideSource {
   title: string;
   url: string;
   publisher: string;
   lastCheckedAt: string;
+  kind: GuideSourceKind;
 }
+
+/**
+ * 临时兼容现有代码，后续可以逐步移除旧名。
+ */
+export type OfficialSource = GuideSource;
 
 export interface ProductGuide {
   productSlug: ProductSlug;
@@ -113,6 +207,7 @@ export interface ProductGuide {
   supportedDeliveryTypes: readonly KnownDeliveryType[];
   overview: readonly GuideBlock[];
   walkthrough?: GuideWalkthrough;
+  workflowReferences?: readonly ProductWorkflowReference[];
   buyingChecklist: readonly string[];
   verificationChecklist: readonly string[];
   riskNotes: readonly string[];
@@ -164,4 +259,5 @@ export interface GuideRegistry {
   products: Readonly<Record<ProductSlug, ProductGuide>>;
   delivery: Readonly<Record<KnownDeliveryType, DeliveryGuide>>;
   general: Readonly<Record<GeneralGuideSlug, GeneralGuide>>;
+  workflows: Readonly<Record<WorkflowGuideSlug, WorkflowGuide>>;
 }

--- a/apps/web/lib/guides/validation.ts
+++ b/apps/web/lib/guides/validation.ts
@@ -3,9 +3,12 @@ import {
   GENERAL_GUIDE_SLUGS,
   KNOWN_DELIVERY_TYPES,
   PRODUCT_SLUGS,
+  WORKFLOW_GUIDE_SLUGS,
+  type GuideSource,
   type GuideRegistry,
-  type OfficialSource,
   type ProductGuide,
+  type WorkflowGuide,
+  type WorkflowGuideSlug,
 } from "./types";
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -26,12 +29,16 @@ function assertUnique(values: readonly string[], label: string): void {
   }
 }
 
-function validateSources(sources: readonly OfficialSource[], label: string): void {
+function validateSources(sources: readonly GuideSource[], label: string): void {
   assert(sources.length > 0, `${label} must include at least one official source`);
   for (const source of sources) {
     assert(source.title.trim(), `${label} has a source without a title`);
     assert(source.publisher.trim(), `${label} has a source without a publisher`);
     assert(source.lastCheckedAt.trim(), `${label} has a source without lastCheckedAt`);
+    assert(
+      source.kind === "platform_official" || source.kind === "project_official",
+      `${label} source ${source.title} has an unknown kind: ${String(source.kind)}`,
+    );
     let url: URL;
     try {
       url = new URL(source.url);
@@ -64,21 +71,81 @@ function productSearchText(product: ProductGuide): string {
   ].join("\n");
 }
 
+function workflowSearchText(workflow: WorkflowGuide): string {
+  const walkthroughText = workflow.variants.flatMap((variant) =>
+    variant.walkthrough.steps.flatMap((step) => [
+      step.title,
+      step.action,
+      ...(step.items ?? []),
+      ...(step.links?.flatMap((link) => [link.label, link.url]) ?? []),
+      step.result,
+      step.trouble ?? "",
+    ]),
+  );
+  return [
+    workflow.title,
+    workflow.description,
+    ...workflow.flow,
+    ...workflow.audience,
+    ...workflow.prerequisites,
+    ...workflow.overview.map((block) => JSON.stringify(block)),
+    ...walkthroughText,
+    ...workflow.verificationChecklist,
+    ...workflow.commonProblems.flatMap((item) => [item.problem, item.likelyCause, item.action]),
+    ...workflow.riskNotes,
+    ...workflow.faq.flatMap((item) => [item.question, item.answer]),
+    ...workflow.sources.flatMap((source) => [source.title, source.url, source.publisher]),
+  ].join("\n");
+}
+
+function validateWorkflowVariants(workflow: WorkflowGuide): void {
+  assertUnique(workflow.variants.map((variant) => variant.id), `variant id in workflow ${workflow.slug}`);
+  for (const variant of workflow.variants) {
+    assert(variant.title.trim(), `workflow ${workflow.slug} variant ${variant.id} is missing title`);
+    assert(variant.description.trim(), `workflow ${workflow.slug} variant ${variant.id} is missing description`);
+    assert(variant.walkthrough.title.trim(), `workflow ${workflow.slug} variant ${variant.id} walkthrough is missing title`);
+    assert(variant.walkthrough.intro.trim(), `workflow ${workflow.slug} variant ${variant.id} walkthrough is missing intro`);
+    assert(variant.walkthrough.steps.length > 0, `workflow ${workflow.slug} variant ${variant.id} walkthrough must include at least one step`);
+    for (const step of variant.walkthrough.steps) {
+      assert(step.title.trim(), `workflow ${workflow.slug} variant ${variant.id} has a step without title`);
+      assert(step.action.trim(), `workflow ${workflow.slug} variant ${variant.id} has a step without action`);
+      assert(step.result.trim(), `workflow ${workflow.slug} variant ${variant.id} has a step without result`);
+      for (const item of step.items ?? []) {
+        assert(item.trim(), `workflow ${workflow.slug} variant ${variant.id} has an empty substep`);
+      }
+      for (const link of step.links ?? []) {
+        assert(link.label.trim(), `workflow ${workflow.slug} variant ${variant.id} has a link without label`);
+        if (link.url.startsWith("/") && !link.url.startsWith("//")) continue;
+        let url: URL;
+        try {
+          url = new URL(link.url);
+        } catch {
+          throw new Error(`Invalid guide registry: workflow ${workflow.slug} variant ${variant.id} has an invalid link: ${link.url}`);
+        }
+        assert(url.protocol === "https:", `workflow ${workflow.slug} variant ${variant.id} link must use HTTPS: ${link.url}`);
+      }
+    }
+  }
+}
+
 export function validateGuideRegistry(registry: GuideRegistry): void {
   const brandValues = Object.values(registry.brands);
   const productValues = Object.values(registry.products);
   const deliveryValues = Object.values(registry.delivery);
   const generalValues = Object.values(registry.general);
+  const workflowValues = Object.values(registry.workflows);
 
   assertExactKeys(Object.keys(registry.brands), BRAND_SLUGS, "brand guide");
   assertExactKeys(Object.keys(registry.products), PRODUCT_SLUGS, "product guide");
   assertExactKeys(Object.keys(registry.delivery), KNOWN_DELIVERY_TYPES, "delivery guide");
   assertExactKeys(Object.keys(registry.general), GENERAL_GUIDE_SLUGS, "general guide");
+  assertExactKeys(Object.keys(registry.workflows), WORKFLOW_GUIDE_SLUGS, "workflow guide");
 
   assertUnique(brandValues.map((guide) => guide.brand), "brand slug");
   assertUnique(productValues.map((guide) => guide.productSlug), "product slug");
   assertUnique(deliveryValues.map((guide) => guide.deliveryType), "delivery slug");
   assertUnique(generalValues.map((guide) => guide.slug), "general guide slug");
+  assertUnique(workflowValues.map((guide) => guide.slug), "workflow guide slug");
 
   for (const [key, guide] of Object.entries(registry.brands)) {
     assert(key === guide.brand, `brand key ${key} does not match guide brand ${guide.brand}`);
@@ -137,6 +204,28 @@ export function validateGuideRegistry(registry: GuideRegistry): void {
       assert(Boolean(registry.delivery[deliveryType]), `product ${product.productSlug} references missing delivery ${deliveryType}`);
     }
 
+    const workflowReferences = product.workflowReferences ?? [];
+    if (product.brand === "openai") {
+      assert(workflowReferences.length > 0, `OpenAI product ${product.productSlug} must reference at least one workflow`);
+    } else {
+      assert(workflowReferences.length === 0, `non-OpenAI product ${product.productSlug} must not reference OpenAI workflows`);
+    }
+    const referencedWorkflowSlugs = new Set<string>();
+    for (const reference of workflowReferences) {
+      assert(
+        reference.workflowSlug && Boolean(registry.workflows[reference.workflowSlug]),
+        `product ${product.productSlug} references missing workflow ${String(reference.workflowSlug)}`,
+      );
+      assert(reference.condition.trim(), `product ${product.productSlug} workflow reference ${reference.workflowSlug} is missing condition`);
+      assert(reference.audience.trim(), `product ${product.productSlug} workflow reference ${reference.workflowSlug} is missing audience`);
+      assert(
+        reference.relevance === "recommended" || reference.relevance === "conditional" || reference.relevance === "advanced",
+        `product ${product.productSlug} workflow reference ${reference.workflowSlug} has an invalid relevance`,
+      );
+      assert(!referencedWorkflowSlugs.has(reference.workflowSlug), `product ${product.productSlug} references workflow ${reference.workflowSlug} more than once`);
+      referencedWorkflowSlugs.add(reference.workflowSlug);
+    }
+
     const searchText = productSearchText(product);
     if (apiProductSlugs.has(product.productSlug)) {
       assert(/API Key/i.test(searchText), `API product ${product.productSlug} is missing API Key guidance`);
@@ -181,4 +270,78 @@ export function validateGuideRegistry(registry: GuideRegistry): void {
     assert(guide.lastReviewedAt.trim(), `general guide ${guide.slug} is missing lastReviewedAt`);
     validateSources(guide.officialSources, `general guide ${guide.slug}`);
   }
+
+  const requiredWorkflowVariants: Partial<Record<WorkflowGuideSlug, readonly string[]>> = {
+    "cockpit-to-codex": ["cc-switch", "codex-plusplus"],
+    "sub2api-to-codex": ["cc-switch", "codex-plusplus"],
+    "api-endpoint-to-codex": ["cc-switch", "codex-plusplus"],
+  };
+
+  for (const [key, workflow] of Object.entries(registry.workflows)) {
+    assert(key === workflow.slug, `workflow key ${key} does not match guide slug ${workflow.slug}`);
+    assert(workflow.title.trim(), `workflow ${workflow.slug} is missing title`);
+    assert(workflow.description.trim(), `workflow ${workflow.slug} is missing description`);
+    assert(workflow.lastReviewedAt.trim(), `workflow ${workflow.slug} is missing lastReviewedAt`);
+    assert(workflow.flow.length >= 3, `workflow ${workflow.slug} must include at least three flow nodes`);
+    assert(workflow.audience.length > 0, `workflow ${workflow.slug} is missing audience`);
+    assert(workflow.prerequisites.length > 0, `workflow ${workflow.slug} is missing prerequisites`);
+    assert(workflow.variants.length > 0, `workflow ${workflow.slug} is missing variants`);
+    assert(workflow.verificationChecklist.length > 0, `workflow ${workflow.slug} is missing verification checklist`);
+    assert(workflow.commonProblems.length > 0, `workflow ${workflow.slug} is missing common problems`);
+    assert(workflow.riskNotes.length > 0, `workflow ${workflow.slug} is missing risk notes`);
+    assert(workflow.faq.length > 0, `workflow ${workflow.slug} is missing FAQ`);
+    validateSources(workflow.sources, `workflow ${workflow.slug}`);
+    assert(
+      workflow.sources.some((source) => source.kind === "platform_official"),
+      `workflow ${workflow.slug} must include at least one platform_official source`,
+    );
+    assert(
+      workflow.sources.some((source) => source.kind === "project_official"),
+      `workflow ${workflow.slug} must include at least one project_official source`,
+    );
+    validateWorkflowVariants(workflow);
+
+    const required = requiredWorkflowVariants[workflow.slug];
+    if (required) {
+      for (const variantId of required) {
+        assert(
+          workflow.variants.some((variant) => variant.id === variantId),
+          `workflow ${workflow.slug} must include ${variantId} variant`,
+        );
+      }
+    }
+  }
+
+  for (const workflow of workflowValues) {
+    const searchText = workflowSearchText(workflow);
+    assert(/第三方/.test(searchText), `workflow ${workflow.slug} is missing third-party disclosure`);
+    assert(/(凭证|密钥)/.test(searchText), `workflow ${workflow.slug} is missing credential guidance`);
+    assert(/(不要上传|不要公开)/.test(searchText), `workflow ${workflow.slug} is missing do-not-upload guidance`);
+  }
+
+  const cockpitSearchText = workflowSearchText(registry.workflows["cockpit-to-codex"]);
+  assert(/本地/.test(cockpitSearchText), "cockpit workflow is missing local guidance");
+  assert(/API 服务/.test(cockpitSearchText), "cockpit workflow is missing API service guidance");
+  assert(/Base URL/.test(cockpitSearchText), "cockpit workflow is missing Base URL guidance");
+
+  const sub2apiSearchText = workflowSearchText(registry.workflows["sub2api-to-codex"]);
+  assert(/HTTPS/.test(sub2apiSearchText), "sub2api workflow is missing HTTPS guidance");
+  assert(/管理员 Key/.test(sub2apiSearchText), "sub2api workflow is missing admin key guidance");
+  assert(/用户 Key/.test(sub2apiSearchText), "sub2api workflow is missing user key guidance");
+
+  const allWorkflowSources = workflowValues.flatMap((workflow) => workflow.sources);
+  const ccSwitchSource = allWorkflowSources.find((source) => source.title === "CC Switch");
+  assert(
+    ccSwitchSource?.url === "https://github.com/farion1231/cc-switch",
+    "CC Switch must point to https://github.com/farion1231/cc-switch",
+  );
+  const codexPlusPlusSource = allWorkflowSources.find((source) => source.title === "CodexPlusPlus");
+  assert(
+    codexPlusPlusSource?.url === "https://github.com/BigPizzaV3/CodexPlusPlus",
+    "Codex++ must point to https://github.com/BigPizzaV3/CodexPlusPlus",
+  );
+
+  const registryText = JSON.stringify(registry);
+  assert(!registryText.includes("ccswitch.cc"), "blacklisted ccswitch.cc URL is present");
+  assert(!/github\.com\/b-nnett\/codex-plusplus/i.test(registryText), "blacklisted codex-plusplus URL is present");
 }

--- a/apps/web/tests/guides-links.test.mjs
+++ b/apps/web/tests/guides-links.test.mjs
@@ -25,6 +25,14 @@ test("all source links are HTTPS and all contextual guide links are internal", (
       assert.match(resolveGuideHref({ productSlug: product.productSlug, deliveryType }), /^\/guides(?:\/|$)/);
     }
   }
+
+  for (const workflow of Object.values(guideRegistry.workflows)) {
+    for (const source of workflow.sources) {
+      const url = new URL(source.url);
+      assert.equal(url.protocol, "https:", source.url);
+      assert.ok(url.hostname.length > 0, source.url);
+    }
+  }
 });
 
 test("canonical path helpers cover index, brands, products, delivery, and general pages", () => {

--- a/apps/web/tests/guides-registry.test.mjs
+++ b/apps/web/tests/guides-registry.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { guideRegistry } from "../lib/guides/registry.ts";
-import { PRODUCT_SLUGS, KNOWN_DELIVERY_TYPES, BRAND_SLUGS, GENERAL_GUIDE_SLUGS } from "../lib/guides/types.ts";
+import { PRODUCT_SLUGS, KNOWN_DELIVERY_TYPES, BRAND_SLUGS, GENERAL_GUIDE_SLUGS, WORKFLOW_GUIDE_SLUGS } from "../lib/guides/types.ts";
 import { validateGuideRegistry } from "../lib/guides/validation.ts";
 
 const EXPECTED_MATRIX = {
@@ -30,11 +30,12 @@ const EXPECTED_MATRIX = {
   "x-premium-plus": ["subscription_recharge", "finished_account"],
 };
 
-test("registry covers every required brand, product, delivery type, and general guide", () => {
+test("registry covers every required brand, product, delivery type, general guide, and workflow guide", () => {
   assert.deepEqual(Object.keys(guideRegistry.brands).sort(), [...BRAND_SLUGS].sort());
   assert.deepEqual(Object.keys(guideRegistry.products).sort(), [...PRODUCT_SLUGS].sort());
   assert.deepEqual(Object.keys(guideRegistry.delivery).sort(), [...KNOWN_DELIVERY_TYPES].sort());
   assert.deepEqual(Object.keys(guideRegistry.general).sort(), [...GENERAL_GUIDE_SLUGS].sort());
+  assert.deepEqual(Object.keys(guideRegistry.workflows).sort(), [...WORKFLOW_GUIDE_SLUGS].sort());
   assert.equal("unknown" in guideRegistry.delivery, false);
   assert.doesNotThrow(() => validateGuideRegistry(guideRegistry));
 });

--- a/apps/web/tests/guides-workflows.test.mjs
+++ b/apps/web/tests/guides-workflows.test.mjs
@@ -129,3 +129,11 @@ test("guide search data includes Cockpit Sub2API CC Switch and Codex++", async (
     assert.ok(source.includes(keyword), keyword);
   }
 });
+
+test("guide workflow search respects brand product and delivery filters", async () => {
+  const pagePath = fileURLToPath(new URL("../app/guides/page.tsx", import.meta.url));
+  const source = await readFile(pagePath, "utf8");
+  assert.match(source, /brand && brand !== "openai"/);
+  assert.match(source, /productGuide\?\.workflowReferences/);
+  assert.match(source, /reference\.workflowSlug === guide\.slug/);
+});

--- a/apps/web/tests/guides-workflows.test.mjs
+++ b/apps/web/tests/guides-workflows.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { getWorkflowGuide, guideRegistry } from "../lib/guides/registry.ts";
+import { WORKFLOW_GUIDE_SLUGS } from "../lib/guides/types.ts";
+
+const workflowValues = Object.values(guideRegistry.workflows);
+
+function workflowSearchText(workflow) {
+  return JSON.stringify(workflow);
+}
+
+test("workflow registry contains all expected workflow slugs", () => {
+  assert.deepEqual(Object.keys(guideRegistry.workflows).sort(), [...WORKFLOW_GUIDE_SLUGS].sort());
+});
+
+test("all OpenAI products reference at least one valid workflow", () => {
+  for (const product of Object.values(guideRegistry.products)) {
+    if (product.brand !== "openai") continue;
+    assert.ok(product.workflowReferences && product.workflowReferences.length > 0, product.productSlug);
+    for (const reference of product.workflowReferences) {
+      assert.ok(getWorkflowGuide(reference.workflowSlug), `${product.productSlug}: ${reference.workflowSlug}`);
+    }
+  }
+});
+
+test("non-OpenAI products do not reference OpenAI workflows", () => {
+  for (const product of Object.values(guideRegistry.products)) {
+    if (product.brand === "openai") continue;
+    assert.ok(!product.workflowReferences || product.workflowReferences.length === 0, product.productSlug);
+  }
+});
+
+test("product workflow references are unique", () => {
+  for (const product of Object.values(guideRegistry.products)) {
+    const references = product.workflowReferences ?? [];
+    const slugs = references.map((reference) => reference.workflowSlug);
+    assert.equal(new Set(slugs).size, slugs.length, product.productSlug);
+  }
+});
+
+test("cockpit workflow includes CC Switch and Codex++ variants", () => {
+  const workflow = guideRegistry.workflows["cockpit-to-codex"];
+  assert.ok(workflow.variants.some((variant) => variant.id === "cc-switch"));
+  assert.ok(workflow.variants.some((variant) => variant.id === "codex-plusplus"));
+});
+
+test("sub2api workflow includes CC Switch and Codex++ variants", () => {
+  const workflow = guideRegistry.workflows["sub2api-to-codex"];
+  assert.ok(workflow.variants.some((variant) => variant.id === "cc-switch"));
+  assert.ok(workflow.variants.some((variant) => variant.id === "codex-plusplus"));
+});
+
+test("direct endpoint workflow includes CC Switch and Codex++ variants", () => {
+  const workflow = guideRegistry.workflows["api-endpoint-to-codex"];
+  assert.ok(workflow.variants.some((variant) => variant.id === "cc-switch"));
+  assert.ok(workflow.variants.some((variant) => variant.id === "codex-plusplus"));
+});
+
+test("CC Switch points to farion1231/cc-switch", () => {
+  const source = workflowValues
+    .flatMap((workflow) => workflow.sources)
+    .find((source) => source.title === "CC Switch");
+  assert.equal(source?.url, "https://github.com/farion1231/cc-switch");
+});
+
+test("Codex++ points to BigPizzaV3/CodexPlusPlus", () => {
+  const source = workflowValues
+    .flatMap((workflow) => workflow.sources)
+    .find((source) => source.title === "CodexPlusPlus");
+  assert.equal(source?.url, "https://github.com/BigPizzaV3/CodexPlusPlus");
+});
+
+test("blacklisted CC Switch and codex-plusplus URLs are absent", () => {
+  const content = JSON.stringify(guideRegistry);
+  assert.doesNotMatch(content, /ccswitch\.cc/);
+  assert.doesNotMatch(content, /github\.com\/b-nnett\/codex-plusplus/i);
+});
+
+test("every workflow warns against exposing credentials", () => {
+  for (const workflow of workflowValues) {
+    const text = workflowSearchText(workflow);
+    assert.match(text, /第三方/, workflow.slug);
+    assert.match(text, /凭证|密钥/, workflow.slug);
+    assert.match(text, /不要上传|不要公开/, workflow.slug);
+  }
+});
+
+test("sub2api workflow distinguishes admin keys from user keys", () => {
+  const text = workflowSearchText(guideRegistry.workflows["sub2api-to-codex"]);
+  assert.match(text, /HTTPS/);
+  assert.match(text, /管理员 Key/);
+  assert.match(text, /用户 Key/);
+});
+
+test("team and K12 products include administrator revocation warning", () => {
+  for (const slug of ["chatgpt-k12", "codex-access"]) {
+    const references = guideRegistry.products[slug].workflowReferences ?? [];
+    assert.ok(references.length > 0, slug);
+    assert.ok(references.some((reference) => /管理员/.test(reference.note ?? "")), slug);
+  }
+});
+
+test("all product workflow links resolve", () => {
+  for (const product of Object.values(guideRegistry.products)) {
+    for (const reference of product.workflowReferences ?? []) {
+      assert.ok(getWorkflowGuide(reference.workflowSlug), `${product.productSlug} -> ${reference.workflowSlug}`);
+      assert.match(`/guides/workflows/${reference.workflowSlug}`, /^\/guides\/workflows\//);
+    }
+  }
+});
+
+test("all workflow pages are included in sitemap", async () => {
+  const sitemapPath = fileURLToPath(new URL("../app/sitemap.ts", import.meta.url));
+  const source = await readFile(sitemapPath, "utf8");
+  assert.match(source, /workflowGuides/);
+  assert.match(source, /\/guides\/workflows\//);
+  for (const slug of WORKFLOW_GUIDE_SLUGS) {
+    assert.ok(source.includes(`workflows/${slug}`) || source.includes(`encodeURIComponent(slug)`), slug);
+  }
+});
+
+test("guide search data includes Cockpit Sub2API CC Switch and Codex++", async () => {
+  const pagePath = fileURLToPath(new URL("../app/guides/page.tsx", import.meta.url));
+  const source = await readFile(pagePath, "utf8");
+  for (const keyword of ["Cockpit", "Sub2API", "CC Switch", "Codex++", "OpenAI 与 Codex 使用工作流"]) {
+    assert.ok(source.includes(keyword), keyword);
+  }
+});


### PR DESCRIPTION
## 概述

新增 OpenAI 商品购买后的 Codex 使用工作流，明确以下上下游关系：

OpenAI 账号或凭证
→ Cockpit（本地）或 Sub2API（服务器）
→ Base URL + API Key
→ CC Switch 或 Codex++
→ Codex CLI / Desktop

四个工具不是四个平行选项，而是上游账号/API 服务与下游客户端配置的组合工作流。

## 主要变更

- 新增 4 个工作流教程：
  - OpenAI 账号用于 Codex 总览
  - Cockpit → CC Switch / Codex++
  - Sub2API → CC Switch / Codex++
  - Base URL + API Key → CC Switch / Codex++
- 所有 OpenAI 产品页新增“购买后如何用于 Codex”
- 新增工作流 registry、类型和严格校验
- Guide Center 首页支持工作流展示与搜索
- sitemap 和结构化数据覆盖工作流页面
- 区分“平台官方”与“项目官方”来源
- 固定项目身份：
  - CC Switch：farion1231/cc-switch
  - Codex++：BigPizzaV3/CodexPlusPlus
- 增加工作流覆盖、链接、来源身份和安全提示测试

## 安全边界

- 不上传或处理用户真实凭证
- 不提交未脱敏截图
- 不承诺第三方账号池、中转或客户端的稳定性
- Team / K12 / Business 页面明确管理员撤销和隐私风险

## 验证

- `npm test`
- `npm run typecheck`
- `npm run build`

## 待人工验证

- Cockpit → CC Switch → Codex
- Cockpit → Codex++ → Codex Desktop
- Sub2API → CC Switch → Codex
- Sub2API → Codex++ → Codex Desktop